### PR TITLE
ci: purge all folders after deployment (hotfix)

### DIFF
--- a/.azuredevops/pipelines/templates/purge-cdn.template.yml
+++ b/.azuredevops/pipelines/templates/purge-cdn.template.yml
@@ -7,43 +7,53 @@ steps:
       scriptLocation: 'inlineScript'
       inlineScript: |
         if [[ $deployment != "none" ]]; then
-          # Purge version folder
+          # Purge all folders
           set -x
           az cdn endpoint purge \
             --resource-group rg-staticcontent-prod-frontend-cdn \
             --profile-name cdn-staticcontent-prod-frontend-cdn \
             --name "fe-solid-design-system-prod" \
-            --content-paths "/$(version)/*" \
+            --content-paths "/*" \
             --no-wait
           set +x
+
+          # Purge version folder
+          # set -x
+          # az cdn endpoint purge \
+          #   --resource-group rg-staticcontent-prod-frontend-cdn \
+          #   --profile-name cdn-staticcontent-prod-frontend-cdn \
+          #   --name "fe-solid-design-system-prod" \
+          #   --content-paths "/$(version)/*" \
+          #   --no-wait
+          # set +x
 
           # Purge patch-wildcard folder
-          set -x
-          az cdn endpoint purge \
-            --resource-group rg-staticcontent-prod-frontend-cdn \
-            --profile-name cdn-staticcontent-prod-frontend-cdn \
-            --name "fe-solid-design-system-prod" \
-            --content-paths "/$(patchWildcardPath)/*" \
-            --no-wait
-          set +x
+          # set -x
+          # az cdn endpoint purge \
+          #   --resource-group rg-staticcontent-prod-frontend-cdn \
+          #   --profile-name cdn-staticcontent-prod-frontend-cdn \
+          #   --name "fe-solid-design-system-prod" \
+          #   --content-paths "/$(patchWildcardPath)/*" \
+          #   --no-wait
+          # set +x
 
           # Purge major-wildcard folder
-          set -x
-          az cdn endpoint purge \
-            --resource-group rg-staticcontent-prod-frontend-cdn \
-            --profile-name cdn-staticcontent-prod-frontend-cdn \
-            --name "fe-solid-design-system-prod" \
-            --content-paths "/$(majorWildcardPath)/*" \
-            --no-wait
-          set +x
+          # set -x
+          # az cdn endpoint purge \
+          #   --resource-group rg-staticcontent-prod-frontend-cdn \
+          #   --profile-name cdn-staticcontent-prod-frontend-cdn \
+          #   --name "fe-solid-design-system-prod" \
+          #   --content-paths "/$(majorWildcardPath)/*" \
+          #   --no-wait
+          # set +x
 
           # Purge minor-wildcard folder
-          set -x
-          az cdn endpoint purge \
-            --resource-group rg-staticcontent-prod-frontend-cdn \
-            --profile-name cdn-staticcontent-prod-frontend-cdn \
-            --name "fe-solid-design-system-prod" \
-            --content-paths "/$(minorWildcardPath)/*" \
-            --no-wait
-          set +x
+          # set -x
+          # az cdn endpoint purge \
+          #   --resource-group rg-staticcontent-prod-frontend-cdn \
+          #   --profile-name cdn-staticcontent-prod-frontend-cdn \
+          #   --name "fe-solid-design-system-prod" \
+          #   --content-paths "/$(minorWildcardPath)/*" \
+          #   --no-wait
+          # set +x
         fi


### PR DESCRIPTION
Currently the purging of the CDN is not working:

![CleanShot 2023-07-26 at 16 40 58@2x](https://github.com/solid-design-system/solid/assets/26542182/3eab4ec2-4337-4083-81de-4ac8e149680d)

I would propose a hotfix for now that purges just everything and create a followup ticket to make it clean.