### PR TITLE
fix: 🤔 sd-accordion focus state

### DIFF
--- a/packages/components/src/components/accordion-group/accordion-group.ts
+++ b/packages/components/src/components/accordion-group/accordion-group.ts
@@ -7,7 +7,7 @@ import SolidElement from '../../internal/solid-element';
 /**
  * @summary Short summary of the component's intended use.
  * @documentation https://solid.union-investment.com/[storybook-link]/accordion-group
- * @status experimental
+ * @status stable
  * @since 1.1
  *
  * @dependency sd-accordion

--- a/packages/components/src/components/accordion/accordion.ts
+++ b/packages/components/src/components/accordion/accordion.ts
@@ -153,7 +153,7 @@ export default class SdAccordion extends SolidElement {
           part="header"
           id="header"
           class=${cx(
-            'flex text-base gap-4 font-bold items-center cursor-pointer select-none px-4 py-3 focus:outline focus:outline-primary focus:outline-2 focus:outline-offset-2 focus-visible:focus',
+            'flex text-base gap-4 font-bold items-center cursor-pointer select-none px-4 py-3 focus-visible:focus-outline',
             this.open ? 'bg-white text-accent hover:bg-neutral-200' : 'text-primary bg-neutral-100 hover:bg-neutral-200'
           )}
           role="button"


### PR DESCRIPTION
## Description:

Fixed styles in sd-accordion to only show focus border during keyboard navigation / tabbed browsing / sr usage.

Changed the status of sd-accordion-group from experimental to stable.
