### PR TITLE
docs: 📚 change defaults for sd-teaser

### DIFF
--- a/packages/components/src/components/teaser/teaser.stories.ts
+++ b/packages/components/src/components/teaser/teaser.stories.ts
@@ -102,11 +102,6 @@ export const InsetAndOrientation = {
           type: 'template',
           name: 'style',
           value: '<div style="margin-bottom: 40px;">%TEMPLATE%</div>'
-        },
-        {
-          type: 'attribute',
-          name: 'variant',
-          value: 'primary-100'
         }
       ]
     });
@@ -119,7 +114,7 @@ export const InsetAndOrientation = {
 
 export const NoMeta = {
   name: 'Empty Meta Slot',
-  parameters: { controls: { exclude: ['meta', 'breakpoint', 'inset'] } },
+  parameters: { controls: { exclude: ['meta', 'breakpoint', 'inset', 'variant'] } },
   render: (args: any) => {
     return generateTemplate({
       axis: {
@@ -154,7 +149,7 @@ export const NoMeta = {
         {
           type: 'attribute',
           name: 'variant',
-          value: 'primary-100'
+          value: 'white border-neutral-300'
         }
       ]
     });
@@ -166,7 +161,7 @@ export const NoMeta = {
  */
 
 export const DistributionRatio = {
-  parameters: { controls: { exclude: ['--distribution-media', '--distribution-content'] } },
+  parameters: { controls: { exclude: ['--distribution-media', '--distribution-content', 'variant'] } },
   render: (args: any) => {
     return generateTemplate({
       axis: {
@@ -201,7 +196,7 @@ export const DistributionRatio = {
         {
           type: 'attribute',
           name: 'variant',
-          value: 'primary-100'
+          value: 'white border-neutral-300'
         }
       ]
     });
@@ -209,11 +204,11 @@ export const DistributionRatio = {
 };
 
 /**
- * When responsive, teaser changes its orientation from `horizontal` to `vertical` at a component's width of 448px.
+ * Breakpoint where the teaser switches from `vertical` to `horizontal`, `0` is always `horizontal`, `9999` is always `vertical`. When responsive, teaser changes its orientation from `horizontal` to `vertical` at a component's width of 448px.
  */
 
 export const Breakpoint = {
-  parameters: { controls: { exclude: 'breakpoint' } },
+  parameters: { controls: { exclude: ['breakpoint', 'variant'] } },
   render: (args: any) => {
     return generateTemplate({
       axis: {
@@ -229,7 +224,7 @@ export const Breakpoint = {
         {
           type: 'attribute',
           name: 'variant',
-          value: 'primary-100'
+          value: 'white border-neutral-300'
         }
       ]
     });
@@ -237,11 +232,11 @@ export const Breakpoint = {
 };
 
 /**
- * Different `headline` sizes. It is also possible to use `sd-link` inside the <h> tag in the headline slot.
+ * Different `headline` sizes. It is also possible to use `sd-link` inside the `<h>` tag in the headline slot.
  */
 
 export const Headline = {
-  parameters: { controls: { exclude: 'headline' } },
+  parameters: { controls: { exclude: ['headline', 'variant'] } },
   render: (args: any) => {
     return html`
       ${['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].map(tag => {
@@ -272,7 +267,7 @@ export const Headline = {
             {
               type: 'attribute',
               name: 'variant',
-              value: 'primary-100'
+              value: 'white border-neutral-300'
             }
           ]
         });
@@ -287,7 +282,7 @@ export const Headline = {
 
 export const Slots = {
   parameters: {
-    controls: { exclude: ['default', 'media', 'meta', 'headline'] }
+    controls: { exclude: ['default', 'media', 'meta', 'headline', 'variant'] }
   },
   render: (args: any) => {
     return html`
@@ -339,7 +334,7 @@ export const Slots = {
             {
               type: 'attribute',
               name: 'variant',
-              value: 'primary-100'
+              value: 'white border-neutral-300'
             }
           ]
         })
@@ -349,7 +344,7 @@ export const Slots = {
 };
 
 export const Parts = {
-  parameters: { controls: { exclude: ['base', 'media', 'content', 'meta', 'headline', 'main'] } },
+  parameters: { controls: { exclude: ['base', 'media', 'content', 'meta', 'headline', 'main', 'variant'] } },
   render: (args: any) => {
     return generateTemplate({
       axis: {
@@ -374,7 +369,7 @@ export const Parts = {
         {
           type: 'attribute',
           name: 'variant',
-          value: 'primary-100'
+          value: 'white border-neutral-300'
         }
       ]
     });


### PR DESCRIPTION
### Description:
I changed the default to 'white border-neutral-300' everywhere but the 'Inset and Orientation Story', since the inset is always set to true in this variant so it wouldn't show the behaviour. Instead I left it on default 'white', but the user can switch between variants in the controls to see how any of them looks like. If you have other suggestions let me know.

Related to #349 