### PR TITLE
fix: 🤔changed paragraph default size to text-base

### DIFF
--- a/packages/components/src/styles/paragraph/paragraph.css
+++ b/packages/components/src/styles/paragraph/paragraph.css
@@ -1,5 +1,5 @@
 .sd-paragraph {
-  @apply text-lg font-normal leading-normal text-black;
+  @apply text-base font-normal leading-normal text-black;
 
   &--size-sm {
     @apply text-sm font-normal leading-normal text-black;


### PR DESCRIPTION
## Description:
Changed the default size of the paragraph component to 16px(text-base) instead of the initial 20px. (text-lg). Closes #406 

## Definition of Reviewable:
*PR notes: Irrelevant elements should be removed.*
- [x] relevant tickets are linked
- [x] PR is assigned to project board
