### PR TITLE
ci: 👷 stop major updates from automerging

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -38,6 +38,9 @@
     "enabled": true,
     "automerge": true
   },
+  "major": {
+    "automerge": false
+  },
   "prConcurrentLimit": 10,
   "automergeType": "pr",
   "automergeStrategy": "squash",

--- a/renovate.json
+++ b/renovate.json
@@ -1,24 +1,33 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", "schedule:daily", ":disableRateLimiting"],
+  "extends": [
+    "config:base",
+    "schedule:daily",
+    ":disableRateLimiting"
+  ],
   "schedule": "before 5am every weekday",
   "timezone": "Europe/Berlin",
   "packageRules": [
     {
-      "matchUpdateTypes": ["minor", "patch"],
-      "matchCurrentVersion": "!/^0/",
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "matchCurrentVersion": ">= 1.0.0",
       "automerge": true
     },
     {
-      "matchDepTypes": ["devDependencies"],
-      "automerge": true
-    },
-    {
-      "matchDepNames": ["node", "pnpm", "nx"],
+      "matchDepNames": [
+        "node",
+        "pnpm",
+        "nx"
+      ],
       "enabled": false
     },
     {
-      "matchPackagePrefixes": ["@types/"],
+      "matchPackagePrefixes": [
+        "@types/"
+      ],
       "automerge": true,
       "major": {
         "automerge": false
@@ -32,6 +41,9 @@
   "prConcurrentLimit": 10,
   "automergeType": "pr",
   "automergeStrategy": "squash",
-  "automergeSchedule": ["after 10pm every weekday", "before 5am every weekday"],
+  "automergeSchedule": [
+    "after 10pm every weekday",
+    "before 5am every weekday"
+  ],
   "autoApprove": true
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,33 +1,20 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base",
-    "schedule:daily",
-    ":disableRateLimiting"
-  ],
+  "extends": ["config:base", "schedule:daily", ":disableRateLimiting"],
   "schedule": "before 5am every weekday",
   "timezone": "Europe/Berlin",
   "packageRules": [
     {
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
+      "matchUpdateTypes": ["minor", "patch"],
       "matchCurrentVersion": ">= 1.0.0",
       "automerge": true
     },
     {
-      "matchDepNames": [
-        "node",
-        "pnpm",
-        "nx"
-      ],
+      "matchDepNames": ["node", "pnpm", "nx"],
       "enabled": false
     },
     {
-      "matchPackagePrefixes": [
-        "@types/"
-      ],
+      "matchPackagePrefixes": ["@types/"],
       "automerge": true,
       "major": {
         "automerge": false
@@ -44,9 +31,6 @@
   "prConcurrentLimit": 10,
   "automergeType": "pr",
   "automergeStrategy": "squash",
-  "automergeSchedule": [
-    "after 10pm every weekday",
-    "before 5am every weekday"
-  ],
+  "automergeSchedule": ["after 10pm every weekday", "before 5am every weekday"],
   "autoApprove": true
 }


### PR DESCRIPTION
## Description:
Removed redundant rule to update dev dependencies that also auto-merged major updates, added blanked rule to turn off automerge for major updates. Closes  #497

## Definition of Reviewable:
*PR notes: Irrelevant elements should be removed.*
- [x] relevant tickets are linked
- [x] PR is assigned to project board