### PR TITLE
docs: prevent primary colors going black

### DIFF
--- a/packages/components/.storybook/addons/theme-generator/Panel.tsx
+++ b/packages/components/.storybook/addons/theme-generator/Panel.tsx
@@ -106,7 +106,7 @@ export const Panel: React.FC<PanelProps> = props => {
             onChange={e => setUseDefaultLuminanceMap(e.target.checked)}
           />
           <label htmlFor="useDefaultLuminanceMap">
-            Normalize colors (This might improve your scale but could reduce accessibility – please check a11y
+            Normalize colors (A normalized scale might match your brand better but could reduce accessibility and usability – make sure to check a11y
             compliance yourself.)
           </label>
         </div>

--- a/packages/components/.storybook/addons/theme-generator/Panel.tsx
+++ b/packages/components/.storybook/addons/theme-generator/Panel.tsx
@@ -106,8 +106,8 @@ export const Panel: React.FC<PanelProps> = props => {
             onChange={e => setUseDefaultLuminanceMap(e.target.checked)}
           />
           <label htmlFor="useDefaultLuminanceMap">
-            Normalize colors (A normalized scale might match your brand better but could reduce accessibility and usability – make sure to check a11y
-            compliance yourself.)
+            Normalize colors (A normalized scale might match your brand better but could reduce accessibility and
+            usability – make sure to check a11y compliance yourself.)
           </label>
         </div>
 

--- a/packages/components/.storybook/addons/theme-generator/Panel.tsx
+++ b/packages/components/.storybook/addons/theme-generator/Panel.tsx
@@ -109,7 +109,8 @@ export const Panel: React.FC<PanelProps> = props => {
               onChange={e => setUseNormalizedLuminanceMap(e.target.checked)}
             />
             <label htmlFor="useNormalizedLuminanceMap">
-              ⚠️ Enable Color Normalization (Toggles the adjustment of color shades for visual consistency. Caution: Verify against accessibility standards for color contrast after applying.)
+              ⚠️ Enable Color Normalization (Toggles the adjustment of color shades for visual consistency. Caution:
+              Verify against accessibility standards for color contrast after applying.)
             </label>
           </div>
           <div>
@@ -120,8 +121,11 @@ export const Panel: React.FC<PanelProps> = props => {
               onChange={e => setUseForcedShades(e.target.checked)}
             />
             <label htmlFor="useForcedShades">
-              ⚠️ Enforce Reference Color (Sets the provided color as the baseline for default shades (primary-600, accent-400). Note: This can significantly impact contrast ratios. Always check for accessibility compliance after changes.)
-            </label></div>
+              ⚠️ Enforce Reference Color (Sets the provided color as the baseline for default shades (primary-600,
+              accent-400). Note: This can significantly impact contrast ratios. Always check for accessibility
+              compliance after changes.)
+            </label>
+          </div>
         </div>
 
         <div style={{ display: 'flex', gap: '8px', marginTop: '12px' }}>

--- a/packages/components/.storybook/addons/theme-generator/Panel.tsx
+++ b/packages/components/.storybook/addons/theme-generator/Panel.tsx
@@ -12,7 +12,8 @@ interface PanelProps {
 }
 
 export const Panel: React.FC<PanelProps> = props => {
-  const [useDefaultLuminanceMap, setUseDefaultLuminanceMap] = useState(PANEL_DEFAULTS.useDefaultLuminanceMap);
+  const [useNormalizedLuminanceMap, setUseNormalizedLuminanceMap] = useState(PANEL_DEFAULTS.useNormalizedLuminanceMap);
+  const [useForcedShades, setUseForcedShades] = useState(PANEL_DEFAULTS.useForcedShades);
 
   const [colors, setColors] = useState(PANEL_DEFAULTS.colors);
 
@@ -40,21 +41,22 @@ export const Panel: React.FC<PanelProps> = props => {
   };
 
   useEffect(() => {
-    setOutput(calculateColorsAsCss(colors, theme, useDefaultLuminanceMap));
-  }, [colors, useDefaultLuminanceMap]);
+    setOutput(calculateColorsAsCss(colors, theme, useNormalizedLuminanceMap, useForcedShades));
+  }, [colors, useNormalizedLuminanceMap, useForcedShades]);
 
   useDebouncedEffect(
     () => {
       const panelState = {
         colors,
-        useDefaultLuminanceMap
+        useNormalizedLuminanceMap,
+        useForcedShades
       };
       updateGlobals({
         [PARAM_KEY + '_STATE']: JSON.stringify(panelState)
       });
     },
     500,
-    [colors, useDefaultLuminanceMap]
+    [colors, useNormalizedLuminanceMap, useForcedShades]
   );
 
   return (
@@ -99,16 +101,27 @@ export const Panel: React.FC<PanelProps> = props => {
         ))}
 
         <div style={{ marginTop: '12px' }}>
-          <input
-            id="useDefaultLuminanceMap"
-            type="checkbox"
-            checked={useDefaultLuminanceMap}
-            onChange={e => setUseDefaultLuminanceMap(e.target.checked)}
-          />
-          <label htmlFor="useDefaultLuminanceMap">
-            Normalize colors (A normalized scale might match your brand better but could reduce accessibility and
-            usability – make sure to check a11y compliance yourself.)
-          </label>
+          <div>
+            <input
+              id="useNormalizedLuminanceMap"
+              type="checkbox"
+              checked={useNormalizedLuminanceMap}
+              onChange={e => setUseNormalizedLuminanceMap(e.target.checked)}
+            />
+            <label htmlFor="useNormalizedLuminanceMap">
+              ⚠️ Enable Color Normalization (Toggles the adjustment of color shades for visual consistency. Caution: Verify against accessibility standards for color contrast after applying.)
+            </label>
+          </div>
+          <div>
+            <input
+              id="useForcedShades"
+              type="checkbox"
+              checked={useForcedShades}
+              onChange={e => setUseForcedShades(e.target.checked)}
+            />
+            <label htmlFor="useForcedShades">
+              ⚠️ Enforce Reference Color (Sets the provided color as the baseline for default shades (primary-600, accent-400). Note: This can significantly impact contrast ratios. Always check for accessibility compliance after changes.)
+            </label></div>
         </div>
 
         <div style={{ display: 'flex', gap: '8px', marginTop: '12px' }}>

--- a/packages/components/.storybook/addons/theme-generator/colorCalculations.ts
+++ b/packages/components/.storybook/addons/theme-generator/colorCalculations.ts
@@ -128,9 +128,7 @@ export const calculateColorsForType = (type, theme, colors, useDefaultLuminanceM
   scale.forEach((currentColor, index) => {
     const scaleValue = scalesForType[index];
     if (scaleValue === 'DEFAULT') {
-      const rgb = chroma(
-        scale[{ primary: useDefaultLuminanceMap ? 4 : 5, accent: useDefaultLuminanceMap ? 4 : 3 }[type]]
-      ).rgb(); // when we normalize the colors, we just use 500 for primary and accent, otherwise we use 600 (primary) or 400 (accent)
+      const rgb = chroma(scale[{ primary: 5, accent: 3 }[type]]).rgb(); //  as default we use 600 (primary) or 400 (accent)
       tokens += `  --sd-color-${type}: ${rgb.join(' ')};\n`;
     } else {
       const rgb = chroma(currentColor).rgb();

--- a/packages/components/.storybook/addons/theme-generator/colorCalculations.ts
+++ b/packages/components/.storybook/addons/theme-generator/colorCalculations.ts
@@ -48,10 +48,6 @@ const calculateLuminanceMap = colorObject => {
   return luminanceMaps;
 };
 
-const gaussian = (x, stdDev = 1) => {
-  return Math.exp(-Math.pow(x, 2) / (2 * Math.pow(stdDev, 2)));
-};
-
 const findClosestLuminanceKey = (luminanceValue, luminanceMap) => {
   const allKeys = Object.keys(luminanceMap).filter(key => key !== 'DEFAULT'); // Exclude the "DEFAULT" key
 
@@ -68,21 +64,43 @@ const findClosestLuminanceKey = (luminanceValue, luminanceMap) => {
 // E. g. if primary-500 fits best, primary-400 and primary-600 will be adjusted more than primary-300 and primary-700
 // Aim is that the whole color palette is most consistent in itself using the original color
 const adjustLuminanceMap = (color, luminanceMap) => {
+  // Calculate the luminance of the given color
   const colorLuminance = chroma(color).luminance();
-  const closestLuminanceKey = findClosestLuminanceKey(colorLuminance, luminanceMap);
-  const closestLuminance = luminanceMap[closestLuminanceKey];
 
-  const difference = colorLuminance - closestLuminance;
-  let newLuminanceMap = {};
+  // Find the closest luminance key in the map
+  const closestLuminanceKey = parseInt(findClosestLuminanceKey(colorLuminance, luminanceMap));
 
-  for (let key in luminanceMap) {
-    let luminanceDistance = closestLuminance - luminanceMap[key];
-    let impactFactor = gaussian(luminanceDistance, 0.5);
-    let adjustment = difference * impactFactor;
+  // Calculate the difference from the closest key's luminance
+  const difference = colorLuminance - luminanceMap[closestLuminanceKey];
 
-    newLuminanceMap[key] = Math.min(1, Math.max(0, luminanceMap[key] + adjustment)); // Clamp between 0 and 1
-  }
-  return newLuminanceMap;
+  // Calculate the gradients for the linear adjustment
+  const gradient = difference / (1000 - closestLuminanceKey);
+
+  let adjustedLuminanceMap = { ...luminanceMap }; // Clone the original map to avoid mutating it directly
+
+  // Apply the linear function to adjust the luminance values
+  Object.keys(adjustedLuminanceMap).forEach(key => {
+    const currentKey = parseInt(key);
+    let adjustment;
+
+    if (currentKey <= closestLuminanceKey) {
+      adjustment = gradient * currentKey;
+    } else {
+      adjustment = gradient * (currentKey - closestLuminanceKey);
+    }
+
+    let adjustedLuminance = luminanceMap[key] + adjustment;
+    // Ensure the adjusted luminance doesn't fall below a minimum threshold to maintain the gradient
+    adjustedLuminance = Math.max(adjustedLuminance, 0.01); // Set minimum luminance threshold
+
+    // Average the adjusted value with the original value to maintain a gradient
+    adjustedLuminanceMap[key] = (adjustedLuminance + luminanceMap[key]) / 2;
+  });
+
+  // Ensure DEFAULT has the luminance of the 500 key
+  adjustedLuminanceMap['DEFAULT'] = adjustedLuminanceMap['500'];
+
+  return adjustedLuminanceMap;
 };
 
 export const calculateColorsForType = (type, theme, colors, useDefaultLuminanceMap) => {
@@ -109,8 +127,15 @@ export const calculateColorsForType = (type, theme, colors, useDefaultLuminanceM
   let tokens = '';
   scale.forEach((currentColor, index) => {
     const scaleValue = scalesForType[index];
-    const rgb = chroma(currentColor).rgb();
-    tokens += `  --sd-color-${type}${scaleValue !== 'DEFAULT' ? `-${scaleValue}` : ''}: ${rgb.join(' ')};\n`;
+    if (scaleValue === 'DEFAULT') {
+      const rgb = chroma(
+        scale[{ primary: useDefaultLuminanceMap ? 4 : 5, accent: useDefaultLuminanceMap ? 4 : 3 }[type]]
+      ).rgb(); // when we normalize the colors, we just use 500 for primary and accent, otherwise we use 600 (primary) or 400 (accent)
+      tokens += `  --sd-color-${type}: ${rgb.join(' ')};\n`;
+    } else {
+      const rgb = chroma(currentColor).rgb();
+      tokens += `  --sd-color-${type}${`-${scaleValue}`}: ${rgb.join(' ')};\n`;
+    }
   });
 
   return tokens;

--- a/packages/components/.storybook/addons/theme-generator/constants.ts
+++ b/packages/components/.storybook/addons/theme-generator/constants.ts
@@ -7,5 +7,6 @@ export const PANEL_DEFAULTS = {
     accent: '#e24a89',
     neutral: '#b0b0b0'
   },
-  useDefaultLuminanceMap: false
+  useNormalizedLuminanceMap: false,
+  useForcedShades: false
 };

--- a/packages/components/.storybook/addons/theme-generator/withGlobals.ts
+++ b/packages/components/.storybook/addons/theme-generator/withGlobals.ts
@@ -14,7 +14,8 @@ export const withGlobals = (StoryFn: StoryFunction<Renderer>, context: StoryCont
   let customTheme = calculateColorsAsCss(
     panelState?.colors || PANEL_DEFAULTS.colors,
     theme,
-    panelState?.useDefaultLuminanceMap || PANEL_DEFAULTS.useDefaultLuminanceMap
+    panelState?.useNormalizedLuminanceMap || PANEL_DEFAULTS.useNormalizedLuminanceMap,
+    panelState?.useForcedShades || PANEL_DEFAULTS.useForcedShades
   );
 
   const isInDocs = context.viewMode === 'docs';


### PR DESCRIPTION
In some occasions, some primary colors went dark when using the tokens creator. This PR should overcome this problem and in general uses a more understandable approach how to calculate the colors.