### PR TITLE
ci: 👷 refine PR title linting

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -26,4 +26,3 @@ jobs:
                 chore
                 ci
                 perf
-                refactor

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,7 @@ Assigning reviewers follows a few rules:
 
 We use Semantic Release to automate versioning and publishing based on commit messages, ensuring consistent release practices. Pull Request titles are especially important for semantic versioning, so follow these guidelines when writing them as well.
 
-Use the following semantic versioning in your commit messages (`feat`, `fix`, `perf`, `docs`, `chore`, `ci`, `refactor`).
+Use the following semantic versioning in your commit messages (`feat`, `fix`, `perf`, `docs`, `chore`, `ci`).
 
 ```
 Commits with a breaking change will be associated with a major release.


### PR DESCRIPTION
## Description:
Removed refactor from the pr-lint allowed semantic terms. Closes #533. 

## Definition of Reviewable:
*PR notes: Irrelevant elements should be removed.*
- [x] Documentation is created/updated
- [x] relevant tickets are linked
- [x] PR is assigned to project board