### PR TITLE
chore: 🔧 add draft-check job to PRs

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -12,6 +12,7 @@ jobs:
       steps:
       - name: Fails in order to indicate that pull request needs to be marked as ready to review and run tests.
         run: exit 1
+
     quality-gate:
         name: Install, verify and build
         runs-on: ubuntu-latest

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -5,18 +5,10 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
 
 jobs: 
-    draft-check:
-      if: github.event.pull_request.draft == true
-      name: Check if pull request is ready to review
-      runs-on: ubuntu-latest
-      steps:
-      - name: Fails in order to indicate that pull request needs to be marked as ready to review and run tests.
-        run: exit 1
-
     quality-gate:
         name: Install, verify and build
         runs-on: ubuntu-latest
-        needs: [draft-check]
+        if: github.event.pull_request.draft == false
         container:
             image: mcr.microsoft.com/playwright:v1.39.0-jammy
         steps:

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -5,6 +5,7 @@ on: pull_request
 jobs: 
     draft-check:
       if: github.event.pull_request.draft == true
+      name: Check if pull request is ready to review
       runs-on: ubuntu-18.04
       steps:
       - name: Fails in order to indicate that pull request needs to be marked as ready to review and run tests.

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -2,10 +2,17 @@ name: Quality Gate
 
 on: pull_request
 
-jobs:
+jobs: 
+    draft-check:
+      if: github.event.pull_request.draft == true
+      runs-on: ubuntu-18.04
+      steps:
+      - name: Fails in order to indicate that pull request needs to be marked as ready to review and run tests.
+        run: exit 1
     quality-gate:
         name: Install, verify and build
         runs-on: ubuntu-latest
+        needs: [draft-check]
         container:
             image: mcr.microsoft.com/playwright:v1.39.0-jammy
         steps:

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -6,7 +6,7 @@ jobs:
     draft-check:
       if: github.event.pull_request.draft == true
       name: Check if pull request is ready to review
-      runs-on: ubuntu-18.04
+      runs-on: ubuntu-latest
       steps:
       - name: Fails in order to indicate that pull request needs to be marked as ready to review and run tests.
         run: exit 1

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -1,6 +1,8 @@
 name: Quality Gate
 
-on: pull_request
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs: 
     draft-check:

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -9,7 +9,7 @@ jobs:
   draft-check:
     if: github.event.pull_request.draft == true
     name: Check if pull request is ready to review
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - name: Fails in order to indicate that pull request needs to be marked as ready to review and run tests.
       run: exit 1

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -8,6 +8,7 @@ permissions: write-all
 jobs:
   draft-check:
     if: github.event.pull_request.draft == true
+    name: Check if pull request is ready to review
     runs-on: ubuntu-18.04
     steps:
     - name: Fails in order to indicate that pull request needs to be marked as ready to review and run tests.

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -13,6 +13,7 @@ jobs:
     steps:
     - name: Fails in order to indicate that pull request needs to be marked as ready to review and run tests.
       run: exit 1
+
   file_size_check:
     runs-on: ubuntu-latest
     needs: [draft-check]

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -8,6 +8,7 @@ permissions: write-all
 jobs:
   file_size_check:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -6,8 +6,15 @@ on:
 permissions: write-all
 
 jobs:
+  draft-check:
+    if: github.event.pull_request.draft == true
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Fails in order to indicate that pull request needs to be marked as ready to review and run tests.
+      run: exit 1
   file_size_check:
     runs-on: ubuntu-latest
+    needs: [draft-check]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -1,7 +1,7 @@
 name: File Size Check
-on: 
+on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions: write-all
 

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -1,4 +1,5 @@
 name: File Size Check
+
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -6,17 +6,8 @@ on:
 permissions: write-all
 
 jobs:
-  draft-check:
-    if: github.event.pull_request.draft == true
-    name: Check if pull request is ready to review
-    runs-on: ubuntu-latest
-    steps:
-    - name: Fails in order to indicate that pull request needs to be marked as ready to review and run tests.
-      run: exit 1
-
   file_size_check:
     runs-on: ubuntu-latest
-    needs: [draft-check]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
closes #580 

After lots of trial and error, this works now:

1. As long as we're in draft mode, all actions are skipped.
2. As soon as it switches to reviewable, all actions start to run.