### PR TITLE
fix: 🤔 sd-chip prevent text wrap

### DIFF
--- a/packages/components/src/styles/chip/chip.css
+++ b/packages/components/src/styles/chip/chip.css
@@ -1,5 +1,5 @@
 .sd-chip {
-  @apply h-6 bg-primary-200 rounded-default text-black text-sm inline-flex items-center px-2 overflow-hidden;
+  @apply h-6 bg-primary-200 rounded-default text-black text-sm inline-flex items-center whitespace-nowrap px-2 overflow-hidden;
 
   &--primary-500 {
     @apply bg-primary-500 text-white;


### PR DESCRIPTION
Because there were no examples yet when merging the sd-chip story, it was not noticed that the sd-chip wraps the text with long content.

### Reproduce
Go to storybook sd-chip -> Chip Samples add long content to sd-chip

### Actual
![actual](https://github.com/solid-design-system/solid/assets/76621625/a7a1b08a-59c9-47cd-bb7c-340e1559680d)

### Expected
![expected](https://github.com/solid-design-system/solid/assets/76621625/2f6cff04-1717-4bb7-b0de-f320118031d1)
