### PR TITLE
fix: 🤔 teaser variant 'white border-neutral-400', - no border around media slot

### DIFF
--- a/packages/components/src/components/teaser/teaser.ts
+++ b/packages/components/src/components/teaser/teaser.ts
@@ -110,7 +110,7 @@ export default class SdTeaser extends SolidElement {
           class=${cx(
             !inset && this._orientation === 'vertical' && 'mb-4',
             !slots['teaser-has-media'] && 'hidden',
-            this.variant === 'white border-neutral-400' && '-m-px'
+            this.variant === 'white border-neutral-400' && this._orientation === 'vertical' && '-m-px'
           )}
           part="media"
         >

--- a/packages/components/src/components/teaser/teaser.ts
+++ b/packages/components/src/components/teaser/teaser.ts
@@ -110,7 +110,7 @@ export default class SdTeaser extends SolidElement {
           class=${cx(
             !inset && this._orientation === 'vertical' && 'mb-4',
             !slots['teaser-has-media'] && 'hidden',
-            this.variant === 'white border-neutral-400' && this._orientation === 'vertical' && '-m-px'
+            this.variant === 'white border-neutral-400' && this._orientation === 'vertical' && 'm-[-1px]'
           )}
           part="media"
         >
@@ -162,10 +162,6 @@ export default class SdTeaser extends SolidElement {
 
       ::slotted([slot='headline']) {
         @apply font-bold !m-0 !text-lg;
-      }
-
-      .-m-px {
-        margin: -1px;
       }
     `
   ];

--- a/packages/components/src/components/teaser/teaser.ts
+++ b/packages/components/src/components/teaser/teaser.ts
@@ -107,7 +107,11 @@ export default class SdTeaser extends SolidElement {
       >
         <div
           style=${this._orientation === 'horizontal' ? `width: var(--distribution-media, 100%);` : ''}
-          class=${cx(!inset && this._orientation === 'vertical' && 'mb-4', !slots['teaser-has-media'] && 'hidden')}
+          class=${cx(
+            !inset && this._orientation === 'vertical' && 'mb-4',
+            !slots['teaser-has-media'] && 'hidden',
+            this.variant === 'white border-neutral-400' && '-m-px'
+          )}
           part="media"
         >
           <slot name="media"></slot>
@@ -158,6 +162,10 @@ export default class SdTeaser extends SolidElement {
 
       ::slotted([slot='headline']) {
         @apply font-bold !m-0 !text-lg;
+      }
+
+      .-m-px {
+        margin: -1px;
       }
     `
   ];

--- a/packages/components/src/components/teaser/teaser.ts
+++ b/packages/components/src/components/teaser/teaser.ts
@@ -110,7 +110,7 @@ export default class SdTeaser extends SolidElement {
           class=${cx(
             !inset && this._orientation === 'vertical' && 'mb-4',
             !slots['teaser-has-media'] && 'hidden',
-            this.variant === 'white border-neutral-400' && this._orientation === 'vertical' && 'm-[-1px]'
+            this.variant === 'white border-neutral-400' && this._orientation === 'vertical' && 'mx-[-1px] mt-[-1px]'
           )}
           part="media"
         >


### PR DESCRIPTION
## Description:
Added negative margin on the media slot in the teaser variant 'white border-neutral-400' so that it overlaps the border and matches the design.

## Definition of Reviewable:
*PR notes: Irrelevant elements should be removed.*
- [x] Documentation is created/updated
- [x] Migration Guide is created/updated
- [x] E2E tests (features, a11y, bug fixes) are created/updated
- [x] Stories (features, a11y) are created/updated
- [x] relevant tickets are linked
- [x] PR is assigned to project board
