### PR TITLE
fix: 🐛 make setCustomValidity() + reportValidity() work with inputs' inline errors

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -10,7 +10,7 @@ jobs:
         runs-on: ubuntu-latest
         if: github.event.pull_request.draft == false
         container:
-            image: mcr.microsoft.com/playwright:v1.39.0-jammy
+            image: mcr.microsoft.com/playwright:v1.40.1-jammy
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -125,6 +125,7 @@
     "lit-html": "^3.0.2",
     "minify-html-literals": "^1.3.5",
     "normalize.css": "^8.0.1",
+    "playwright": "^1.40.1",
     "plop": "^4.0.0",
     "postcss": "^8.4.31",
     "prettier": "^3.0.3",

--- a/packages/components/src/components/checkbox/checkbox.stories.ts
+++ b/packages/components/src/components/checkbox/checkbox.stories.ts
@@ -295,7 +295,9 @@ const checkboxTemplate = (part: string) => {
  */
 
 export const setCustomValidity = {
-  chromatic: { disableSnapshot: true },
+  parameters: {
+    chromatic: { disableSnapshot: true }
+  },
   render: () => {
     return html`
       <!-- block submit and show alert instead -->

--- a/packages/components/src/components/checkbox/checkbox.stories.ts
+++ b/packages/components/src/components/checkbox/checkbox.stories.ts
@@ -287,3 +287,61 @@ const checkboxTemplate = (part: string) => {
       return `<sd-checkbox>Default Slot</sd-checkbox>`;
   }
 };
+
+/**
+ * 1. You can use the `setCustomValidity` method to set a custom validation message. This will override any native validation messages.
+ * 2. Set an empty string to clear the custom validity and make the input valid.
+ * 3. To show the validation message, call the `reportValidity` method. Originally this would show a native validation bubble, but we show the error messages inline.
+ */
+
+export const setCustomValidity = {
+  chromatic: { disableSnapshot: true },
+  render: () => {
+    return html`
+      <!-- block submit and show alert instead -->
+      <form id="validationForm" class="flex flex-col gap-2">
+        <sd-checkbox id="custom-input">Checkbox</sd-checkbox>
+        <div>
+          <sd-button type="submit">Submit</sd-button>
+          <sd-button id="error-button" variant="secondary">Set custom error</sd-button>
+          <sd-button id="success-button" variant="secondary">Set success</sd-button>
+          <sd-button type="reset" variant="secondary">Reset</sd-button>
+        </div>
+      </form>
+      <script type="module">
+        // Wait for custom elements to be defined
+        await Promise.all([customElements.whenDefined('sd-checkbox'), customElements.whenDefined('sd-button')]).then(
+          () => {
+            const form = document.getElementById('validationForm');
+            const input = document.getElementById('custom-input');
+            const setErrorButton = document.getElementById('error-button');
+            const setSuccessButton = document.getElementById('success-button');
+
+            // Initial error
+            const errorMessage = \`This is an initial custom error (\${new Date().toLocaleTimeString()})\`;
+            input.setCustomValidity(errorMessage);
+            input.reportValidity();
+
+            // Show error message
+            setErrorButton.addEventListener('click', () => {
+              const errorMessage = \`This is a new custom error (\${new Date().toLocaleTimeString()})\`;
+              input.setCustomValidity(errorMessage);
+              input.reportValidity();
+            });
+
+            // Show success message
+            setSuccessButton.addEventListener('click', () => {
+              input.setCustomValidity(''); // Clear custom validity
+              input.reportValidity();
+            });
+
+            form.addEventListener('submit', event => {
+              event.preventDefault();
+              alert('All fields are valid!');
+            });
+          }
+        );
+      </script>
+    `;
+  }
+};

--- a/packages/components/src/components/checkbox/checkbox.test.ts
+++ b/packages/components/src/components/checkbox/checkbox.test.ts
@@ -163,6 +163,41 @@ describe('<sd-checkbox>', () => {
       expect(checkbox.hasAttribute('data-user-valid')).to.be.false;
     });
 
+    it('should show invalid-message when calling reportCustomValidity with non-empty setCustomValidity() ', async () => {
+      const input = await fixture<SdCheckbox>(html` <sd-checkbox></sd-checkbox> `);
+
+      input.setCustomValidity('Invalid selection');
+      await input.updateComplete;
+
+      input.reportValidity();
+      await input.updateComplete;
+      await input.updateComplete; // Currently there are two updates in the component
+
+      expect(input.shadowRoot!.querySelector('#invalid-message')!.hasAttribute('hidden')).to.be.false;
+    });
+
+    it('should hide invalid-message when calling reportCustomValidity with empty setCustomValidity() ', async () => {
+      const input = await fixture<SdCheckbox>(html` <sd-checkbox></sd-checkbox> `);
+
+      input.setCustomValidity('Invalid selection');
+      await input.updateComplete;
+
+      input.reportValidity();
+      await input.updateComplete;
+      await input.updateComplete; // Currently there are two updates in the component
+
+      expect(input.shadowRoot!.querySelector('#invalid-message')!.hasAttribute('hidden')).to.be.false;
+
+      input.setCustomValidity('');
+      await input.updateComplete;
+
+      input.reportValidity();
+      await input.updateComplete;
+      await input.updateComplete; // Currently there are two updates in the component
+
+      expect(input.shadowRoot!.querySelector('#invalid-message')!.hasAttribute('hidden')).to.be.true;
+    });
+
     it('should be invalid when required and unchecked', async () => {
       const checkbox = await fixture<HTMLFormElement>(html` <sd-checkbox required></sd-checkbox> `);
       expect(checkbox.checkValidity()).to.be.false;

--- a/packages/components/src/components/checkbox/checkbox.ts
+++ b/packages/components/src/components/checkbox/checkbox.ts
@@ -159,6 +159,7 @@ export default class SdCheckbox extends SolidElement implements SolidFormControl
 
   /** Checks for validity and shows a validation message if the control is invalid. */
   reportValidity() {
+    this.formControlController.fakeUserInteraction();
     return this.input.reportValidity();
   }
 

--- a/packages/components/src/components/input/input.stories.ts
+++ b/packages/components/src/components/input/input.stories.ts
@@ -715,17 +715,23 @@ export const Parts = {
 };
 
 /**
- * `sd-input` is fully accessibile via keyboard.
+ * 1. You can use the `setCustomValidity` method to set a custom validation message. This will override any native validation messages.
+ * 2. Set an empty string to clear the custom validity and make the input valid.
+ * 3. To show the validation message, call the `reportValidity` method. Originally this would show a native validation bubble, but we show the error messages inline.
  */
 
 export const setCustomValidity = {
+  chromatic: { disableSnapshot: true },
   render: () => {
     return html`
+      <!-- block submit and show alert instead -->
       <form id="validationForm" class="flex flex-col gap-2">
-        <sd-input id="customInput" label="Input"></sd-input>
+        <sd-input id="custom-input" label="Input"></sd-input>
         <div>
-          <sd-button id="setErrorButton">Set error</sd-button>
-          <sd-button id="clearErrorButton" variant="secondary">Remove error</sd-button>
+          <sd-button type="submit">Submit</sd-button>
+          <sd-button id="error-button" variant="secondary">Set custom error</sd-button>
+          <sd-button id="success-button" variant="secondary">Set success</sd-button>
+          <sd-button type="reset" variant="secondary">Reset</sd-button>
         </div>
       </form>
       <script type="module">
@@ -733,19 +739,31 @@ export const setCustomValidity = {
         await Promise.all([customElements.whenDefined('sd-input'), customElements.whenDefined('sd-button')]).then(
           () => {
             const form = document.getElementById('validationForm');
-            const input = document.getElementById('customInput');
-            const setErrorButton = document.getElementById('setErrorButton');
-            const clearErrorButton = document.getElementById('clearErrorButton');
+            const input = document.getElementById('custom-input');
+            const setErrorButton = document.getElementById('error-button');
+            const setSuccessButton = document.getElementById('success-button');
 
+            // Initial error
+            const errorMessage = \`This is an initial custom error (\${new Date().toLocaleTimeString()})\`;
+            input.setCustomValidity(errorMessage);
+            input.reportValidity();
+
+            // Show error message
             setErrorButton.addEventListener('click', () => {
-              const errorMessage = \`Error set at \${new Date().toLocaleTimeString()}\`;
+              const errorMessage = \`This is a new custom error (\${new Date().toLocaleTimeString()})\`;
               input.setCustomValidity(errorMessage);
               input.reportValidity();
             });
 
-            clearErrorButton.addEventListener('click', () => {
+            // Show success message
+            setSuccessButton.addEventListener('click', () => {
               input.setCustomValidity(''); // Clear custom validity
               input.reportValidity();
+            });
+
+            form.addEventListener('submit', event => {
+              event.preventDefault();
+              alert('All fields are valid!');
             });
           }
         );

--- a/packages/components/src/components/input/input.stories.ts
+++ b/packages/components/src/components/input/input.stories.ts
@@ -718,6 +718,46 @@ export const Parts = {
  * `sd-input` is fully accessibile via keyboard.
  */
 
+export const setCustomValidity = {
+  render: () => {
+    return html`
+      <form id="validationForm" class="flex flex-col gap-2">
+        <sd-input id="customInput" label="Input"></sd-input>
+        <div>
+          <sd-button id="setErrorButton">Set error</sd-button>
+          <sd-button id="clearErrorButton" variant="secondary">Remove error</sd-button>
+        </div>
+      </form>
+      <script type="module">
+        // Wait for custom elements to be defined
+        await Promise.all([customElements.whenDefined('sd-input'), customElements.whenDefined('sd-button')]).then(
+          () => {
+            const form = document.getElementById('validationForm');
+            const input = document.getElementById('customInput');
+            const setErrorButton = document.getElementById('setErrorButton');
+            const clearErrorButton = document.getElementById('clearErrorButton');
+
+            setErrorButton.addEventListener('click', () => {
+              const errorMessage = \`Error set at \${new Date().toLocaleTimeString()}\`;
+              input.setCustomValidity(errorMessage);
+              input.reportValidity();
+            });
+
+            clearErrorButton.addEventListener('click', () => {
+              input.setCustomValidity(''); // Clear custom validity
+              input.reportValidity();
+            });
+          }
+        );
+      </script>
+    `;
+  }
+};
+
+/**
+ * `sd-input` is fully accessibile via keyboard.
+ */
+
 export const Mouseless = {
   render: (args: any) => {
     return html`<div class="mouseless w-[250px]">${generateTemplate({ args })}</div>`;

--- a/packages/components/src/components/input/input.stories.ts
+++ b/packages/components/src/components/input/input.stories.ts
@@ -721,7 +721,9 @@ export const Parts = {
  */
 
 export const setCustomValidity = {
-  chromatic: { disableSnapshot: true },
+  parameters: {
+    chromatic: { disableSnapshot: true }
+  },
   render: () => {
     return html`
       <!-- block submit and show alert instead -->

--- a/packages/components/src/components/input/input.test.ts
+++ b/packages/components/src/components/input/input.test.ts
@@ -201,7 +201,7 @@ describe('<sd-input>', () => {
     });
 
     it('should be invalid when setCustomValidity() is called with a non-empty value', async () => {
-      const input = await fixture<HTMLFormElement>(html` <sd-input></sd-input> `);
+      const input = await fixture<SdInput>(html` <sd-input></sd-input> `);
 
       input.setCustomValidity('Invalid selection');
       await input.updateComplete;
@@ -220,39 +220,42 @@ describe('<sd-input>', () => {
       expect(input.hasAttribute('data-user-valid')).to.be.false;
     });
 
-    it('should render #invalid-message inside the component when setCustomValidity() and reportCustomValidity() is called with a non-empty value', async () => {
-      const input = await fixture<HTMLFormElement>(html` <sd-input></sd-input> `);
+    it('should show invalid-message when calling reportCustomValidity with non-empty setCustomValidity() ', async () => {
+      const input = await fixture<SdInput>(html` <sd-input></sd-input> `);
 
       input.setCustomValidity('Invalid selection');
       await input.updateComplete;
 
       input.reportValidity();
       await input.updateComplete;
+      await input.updateComplete; // Currently there are two updates in the component
 
-      expect(input.shadowRoot!.querySelector('[part~="invalid-message"]')).to.exist;
+      expect(input.shadowRoot!.querySelector('#invalid-message')!.hasAttribute('hidden')).to.be.false;
     });
 
-    it('should not render #invalid-message inside the component when setCustomValidity() and reportCustomValidity() is called with an empty value', async () => {
-      const input = await fixture<HTMLFormElement>(html` <sd-input></sd-input> `);
+    it('should hide invalid-message when calling reportCustomValidity with empty setCustomValidity() ', async () => {
+      const input = await fixture<SdInput>(html` <sd-input></sd-input> `);
 
       input.setCustomValidity('Invalid selection');
       await input.updateComplete;
 
       input.reportValidity();
       await input.updateComplete;
+      await input.updateComplete; // Currently there are two updates in the component
 
-      expect(input.shadowRoot!.querySelector('[part~="invalid-message"]')).to.exist;
+      expect(input.shadowRoot!.querySelector('#invalid-message')!.hasAttribute('hidden')).to.be.false;
 
       input.setCustomValidity('');
       await input.updateComplete;
 
       input.reportValidity();
       await input.updateComplete;
+      await input.updateComplete; // Currently there are two updates in the component
 
-      expect(input.shadowRoot!.querySelector('[part~="invalid-message"]')).to.not.exist;
+      expect(input.shadowRoot!.querySelector('#invalid-message')!.hasAttribute('hidden')).to.be.true;
     });
 
-    it('should show sd-icon with name="confirm" when setCustomValidity() is called with an empty value', async () => {
+    it('should show correct icon when calling reportValidity()', async () => {
       const input = await fixture<HTMLFormElement>(html` <sd-input></sd-input> `);
 
       input.setCustomValidity('Invalid selection');
@@ -260,16 +263,20 @@ describe('<sd-input>', () => {
 
       input.reportValidity();
       await input.updateComplete;
+      await input.updateComplete; // Currently there are two updates in the component
 
       expect(input.shadowRoot!.querySelector('[part~="invalid-icon"]')).to.exist;
+      expect(input.shadowRoot!.querySelector('[part~="valid-icon"]')).to.not.exist;
 
       input.setCustomValidity('');
       await input.updateComplete;
 
       input.reportValidity();
       await input.updateComplete;
+      await input.updateComplete; // Currently there are two updates in the component
 
       expect(input.shadowRoot!.querySelector('[part~="invalid-icon"]')).to.not.exist;
+      expect(input.shadowRoot!.querySelector('[part~="valid-icon"]')).to.exist;
     });
 
     it('should be present in form data when using the form attribute and located outside of a <form>', async () => {

--- a/packages/components/src/components/input/input.test.ts
+++ b/packages/components/src/components/input/input.test.ts
@@ -220,6 +220,43 @@ describe('<sd-input>', () => {
       expect(input.hasAttribute('data-user-valid')).to.be.false;
     });
 
+    it('should render #invalid-message inside the component when setCustomValidity() is called with a non-empty value', async () => {
+      const input = await fixture<HTMLFormElement>(html` <sd-input></sd-input> `);
+
+      input.setCustomValidity('Invalid selection');
+      await input.updateComplete;
+
+      expect(input.shadowRoot!.querySelector('[part~="invalid-message"]')).to.exist;
+    });
+
+    it('should not render #invalid-message inside the component when setCustomValidity() is called with an empty value', async () => {
+      const input = await fixture<HTMLFormElement>(html` <sd-input></sd-input> `);
+
+      input.setCustomValidity('Invalid selection');
+      await input.updateComplete;
+
+      expect(input.shadowRoot!.querySelector('[part~="invalid-message"]')).to.exist;
+
+      input.setCustomValidity('');
+      await input.updateComplete;
+
+      expect(input.shadowRoot!.querySelector('[part~="invalid-message"]')).to.not.exist;
+    });
+
+    it('should show sd-icon with name="confirm" when setCustomValidity() is called with an empty value', async () => {
+      const input = await fixture<HTMLFormElement>(html` <sd-input></sd-input> `);
+
+      input.setCustomValidity('Invalid selection');
+      await input.updateComplete;
+
+      expect(input.shadowRoot!.querySelector('[part~="invalid-icon"]')).to.exist;
+
+      input.setCustomValidity('');
+      await input.updateComplete;
+
+      expect(input.shadowRoot!.querySelector('[part~="invalid-icon"]')).to.not.exist;
+    });
+
     it('should be present in form data when using the form attribute and located outside of a <form>', async () => {
       const el = await fixture<HTMLFormElement>(html`
         <div>

--- a/packages/components/src/components/input/input.test.ts
+++ b/packages/components/src/components/input/input.test.ts
@@ -220,24 +220,33 @@ describe('<sd-input>', () => {
       expect(input.hasAttribute('data-user-valid')).to.be.false;
     });
 
-    it('should render #invalid-message inside the component when setCustomValidity() is called with a non-empty value', async () => {
+    it('should render #invalid-message inside the component when setCustomValidity() and reportCustomValidity() is called with a non-empty value', async () => {
       const input = await fixture<HTMLFormElement>(html` <sd-input></sd-input> `);
 
       input.setCustomValidity('Invalid selection');
+      await input.updateComplete;
+
+      input.reportValidity();
       await input.updateComplete;
 
       expect(input.shadowRoot!.querySelector('[part~="invalid-message"]')).to.exist;
     });
 
-    it('should not render #invalid-message inside the component when setCustomValidity() is called with an empty value', async () => {
+    it('should not render #invalid-message inside the component when setCustomValidity() and reportCustomValidity() is called with an empty value', async () => {
       const input = await fixture<HTMLFormElement>(html` <sd-input></sd-input> `);
 
       input.setCustomValidity('Invalid selection');
       await input.updateComplete;
 
+      input.reportValidity();
+      await input.updateComplete;
+
       expect(input.shadowRoot!.querySelector('[part~="invalid-message"]')).to.exist;
 
       input.setCustomValidity('');
+      await input.updateComplete;
+
+      input.reportValidity();
       await input.updateComplete;
 
       expect(input.shadowRoot!.querySelector('[part~="invalid-message"]')).to.not.exist;
@@ -249,9 +258,15 @@ describe('<sd-input>', () => {
       input.setCustomValidity('Invalid selection');
       await input.updateComplete;
 
+      input.reportValidity();
+      await input.updateComplete;
+
       expect(input.shadowRoot!.querySelector('[part~="invalid-icon"]')).to.exist;
 
       input.setCustomValidity('');
+      await input.updateComplete;
+
+      input.reportValidity();
       await input.updateComplete;
 
       expect(input.shadowRoot!.querySelector('[part~="invalid-icon"]')).to.not.exist;

--- a/packages/components/src/components/input/input.ts
+++ b/packages/components/src/components/input/input.ts
@@ -59,6 +59,9 @@ const isFirefox = isChromium ? false : navigator.userAgent.includes('Firefox');
  * @csspart clear-button - The clear button.
  * @csspart password-toggle-button - The password toggle button.
  * @csspart right - The container that wraps the right.
+ * @csspart invalid-icon - The invalid icon.
+ * @csspart valid-icon - The valid icon.
+ * @csspart invalid-message - The invalid message.
  */
 
 @customElement('sd-input')
@@ -397,6 +400,7 @@ export default class SdInput extends SolidElement implements SolidFormControl {
 
   /** Checks for validity and shows the browser's validation message if the control is invalid. */
   reportValidity() {
+    this.formControlController.fakeUserInteraction();
     return this.input.reportValidity();
   }
 
@@ -609,7 +613,12 @@ export default class SdInput extends SolidElement implements SolidFormControl {
               : ''}
             ${this.showInvalidStyle
               ? html`
-                  <sd-icon class=${cx('text-error', iconMarginLeft, iconSize)} library="system" name="risk"></sd-icon>
+                  <sd-icon
+                    part="invalid-icon"
+                    class=${cx('text-error', iconMarginLeft, iconSize)}
+                    library="system"
+                    name="risk"
+                  ></sd-icon>
                 `
               : ''}
             ${this.showValidStyle
@@ -618,6 +627,7 @@ export default class SdInput extends SolidElement implements SolidFormControl {
                     class=${cx('text-success', iconMarginLeft, iconSize)}
                     library="system"
                     name="confirm"
+                    part="valid-icon"
                   ></sd-icon>
                 `
               : ''}

--- a/packages/components/src/components/radio-group/radio-group.stories.ts
+++ b/packages/components/src/components/radio-group/radio-group.stories.ts
@@ -253,3 +253,66 @@ export const MouselessWithRadioButtons = {
     el?.shadowRoot?.querySelector('button')!.focus();
   }
 };
+
+/**
+ * 1. You can use the `setCustomValidity` method to set a custom validation message. This will override any native validation messages.
+ * 2. Set an empty string to clear the custom validity and make the input valid.
+ * 3. To show the validation message, call the `reportValidity` method. Originally this would show a native validation bubble, but we show the error messages inline.
+ */
+
+export const setCustomValidity = {
+  chromatic: { disableSnapshot: true },
+  render: () => {
+    return html`
+      <!-- block submit and show alert instead -->
+      <form id="validationForm" class="flex flex-col gap-2">
+        <sd-radio-group id="custom-input">
+          <sd-radio id="radio-1" name="a" value="1">1</sd-radio>
+          <sd-radio id="radio-2" name="a" value="2">2</sd-radio>
+        </sd-radio-group>
+        <div>
+          <sd-button type="submit">Submit</sd-button>
+          <sd-button id="error-button" variant="secondary">Set custom error</sd-button>
+          <sd-button id="success-button" variant="secondary">Set success</sd-button>
+          <sd-button type="reset" variant="secondary">Reset</sd-button>
+        </div>
+      </form>
+      <script type="module">
+        // Wait for custom elements to be defined
+        await Promise.all([
+          customElements.whenDefined('sd-radio-group'),
+          customElements.whenDefined('sd-button'),
+          customElements.whenDefined('sd-radio')
+        ]).then(() => {
+          const form = document.getElementById('validationForm');
+          const input = document.getElementById('custom-input');
+          const setErrorButton = document.getElementById('error-button');
+          const setSuccessButton = document.getElementById('success-button');
+
+          // Initial error
+          const errorMessage = \`This is an initial custom error (\${new Date().toLocaleTimeString()})\`;
+          input.setCustomValidity(errorMessage);
+          input.reportValidity();
+
+          // Show error message
+          setErrorButton.addEventListener('click', () => {
+            const errorMessage = \`This is a new custom error (\${new Date().toLocaleTimeString()})\`;
+            input.setCustomValidity(errorMessage);
+            input.reportValidity();
+          });
+
+          // Show success message
+          setSuccessButton.addEventListener('click', () => {
+            input.setCustomValidity(''); // Clear custom validity
+            input.reportValidity();
+          });
+
+          form.addEventListener('submit', event => {
+            event.preventDefault();
+            alert('All fields are valid!');
+          });
+        });
+      </script>
+    `;
+  }
+};

--- a/packages/components/src/components/radio-group/radio-group.stories.ts
+++ b/packages/components/src/components/radio-group/radio-group.stories.ts
@@ -261,7 +261,9 @@ export const MouselessWithRadioButtons = {
  */
 
 export const setCustomValidity = {
-  chromatic: { disableSnapshot: true },
+  parameters: {
+    chromatic: { disableSnapshot: true }
+  },
   render: () => {
     return html`
       <!-- block submit and show alert instead -->

--- a/packages/components/src/components/radio-group/radio-group.test.ts
+++ b/packages/components/src/components/radio-group/radio-group.test.ts
@@ -155,6 +155,51 @@ describe('<sd-radio-group>', () => {
 
     expect(submitHandler).to.not.have.been.called;
   });
+
+  it('should show invalid-message when calling reportCustomValidity with non-empty setCustomValidity() ', async () => {
+    const input = await fixture<SdRadioGroup>(html`
+      <sd-radio-group value="1">
+        <sd-radio id="radio-1" name="a" value="1"></sd-radio>
+        <sd-radio id="radio-2" name="a" value="2"></sd-radio>
+      </sd-radio-group>
+    `);
+
+    input.setCustomValidity('Invalid selection');
+    await input.updateComplete;
+
+    input.reportValidity();
+    await input.updateComplete;
+    await input.updateComplete; // Currently there are two updates in the component
+
+    expect(input.shadowRoot!.querySelector('#invalid-message')!.hasAttribute('hidden')).to.be.false;
+  });
+
+  it('should hide invalid-message when calling reportCustomValidity with empty setCustomValidity() ', async () => {
+    const input = await fixture<SdRadioGroup>(html`
+      <sd-radio-group>
+        <sd-radio id="radio-1" name="a" value="1"></sd-radio>
+        <sd-radio id="radio-2" name="a" value="2"></sd-radio>
+      </sd-radio-group>
+    `);
+
+    input.setCustomValidity('Invalid selection');
+    await input.updateComplete;
+
+    input.reportValidity();
+    await input.updateComplete;
+    await input.updateComplete; // Currently there are two updates in the component
+
+    expect(input.shadowRoot!.querySelector('#invalid-message')!.hasAttribute('hidden')).to.be.false;
+
+    input.setCustomValidity('');
+    await input.updateComplete;
+
+    input.reportValidity();
+    await input.updateComplete;
+    await input.updateComplete; // Currently there are two updates in the component
+
+    expect(input.shadowRoot!.querySelector('#invalid-message')!.hasAttribute('hidden')).to.be.true;
+  });
 });
 
 describe('when resetting a form', () => {

--- a/packages/components/src/components/radio-group/radio-group.ts
+++ b/packages/components/src/components/radio-group/radio-group.ts
@@ -331,6 +331,8 @@ export default class SdRadioGroup extends SolidElement implements SolidFormContr
     this.validationInput.hidden = true;
     clearTimeout(this.validationTimeout);
 
+    this.formControlController.fakeUserInteraction();
+
     if (!isValid) {
       // Show the browser's constraint validation message
       this.validationInput.hidden = false;

--- a/packages/components/src/components/select/select.stories.ts
+++ b/packages/components/src/components/select/select.stories.ts
@@ -499,6 +499,70 @@ export const SampleForm = {
 };
 
 /**
+ * 1. You can use the `setCustomValidity` method to set a custom validation message. This will override any native validation messages.
+ * 2. Set an empty string to clear the custom validity and make the input valid.
+ * 3. To show the validation message, call the `reportValidity` method. Originally this would show a native validation bubble, but we show the error messages inline.
+ */
+
+export const setCustomValidity = {
+  chromatic: { disableSnapshot: true },
+  render: () => {
+    return html`
+      <!-- block submit and show alert instead -->
+      <form id="validationForm" class="flex flex-col gap-2">
+        <sd-select id="custom-input">
+          <sd-option value="option-1">Option 1</sd-option>
+          <sd-option value="option-2">Option 2</sd-option>
+          <sd-option value="option-3">Option 3</sd-option>
+        </sd-select>
+        <div>
+          <sd-button type="submit">Submit</sd-button>
+          <sd-button id="error-button" variant="secondary">Set custom error</sd-button>
+          <sd-button id="success-button" variant="secondary">Set success</sd-button>
+          <sd-button type="reset" variant="secondary">Reset</sd-button>
+        </div>
+      </form>
+      <script type="module">
+        // Wait for custom elements to be defined
+        await Promise.all([
+          customElements.whenDefined('sd-select'),
+          customElements.whenDefined('sd-button'),
+          customElements.whenDefined('sd-option')
+        ]).then(() => {
+          const form = document.getElementById('validationForm');
+          const input = document.getElementById('custom-input');
+          const setErrorButton = document.getElementById('error-button');
+          const setSuccessButton = document.getElementById('success-button');
+
+          // Initial error
+          const errorMessage = \`This is an initial custom error (\${new Date().toLocaleTimeString()})\`;
+          input.setCustomValidity(errorMessage);
+          input.reportValidity();
+
+          // Show error message
+          setErrorButton.addEventListener('click', () => {
+            const errorMessage = \`This is a new custom error (\${new Date().toLocaleTimeString()})\`;
+            input.setCustomValidity(errorMessage);
+            input.reportValidity();
+          });
+
+          // Show success message
+          setSuccessButton.addEventListener('click', () => {
+            input.setCustomValidity(''); // Clear custom validity
+            input.reportValidity();
+          });
+
+          form.addEventListener('submit', event => {
+            event.preventDefault();
+            alert('All fields are valid!');
+          });
+        });
+      </script>
+    `;
+  }
+};
+
+/**
  * Demonstrates a form containing all existing Solid form elements.
  */
 

--- a/packages/components/src/components/select/select.stories.ts
+++ b/packages/components/src/components/select/select.stories.ts
@@ -505,7 +505,9 @@ export const SampleForm = {
  */
 
 export const setCustomValidity = {
-  chromatic: { disableSnapshot: true },
+  parameters: {
+    chromatic: { disableSnapshot: true }
+  },
   render: () => {
     return html`
       <!-- block submit and show alert instead -->

--- a/packages/components/src/components/select/select.test.ts
+++ b/packages/components/src/components/select/select.test.ts
@@ -378,6 +378,96 @@ describe('<sd-select>', () => {
 
       expect(formData.get('a')).to.equal('option-1');
     });
+
+    it('should show invalid-message when calling reportCustomValidity with non-empty setCustomValidity() ', async () => {
+      const input = await fixture<SdSelect>(html`
+        <sd-select name="a" value="option-1">
+          <sd-option value="option-1">Option 1</sd-option>
+          <sd-option value="option-2">Option 2</sd-option>
+          <sd-option value="option-3">Option 3</sd-option>
+        </sd-select>
+      `);
+      input.setCustomValidity('Invalid selection');
+      await input.updateComplete;
+
+      input.reportValidity();
+      await input.updateComplete;
+      await input.updateComplete; // Currently there are two updates in the component
+
+      expect(input.shadowRoot!.querySelector('#invalid-message')!.hasAttribute('hidden')).to.be.false;
+    });
+
+    it('should hide invalid-message when calling reportCustomValidity with empty setCustomValidity() ', async () => {
+      const input = await fixture<SdSelect>(html`
+        <sd-select name="a" value="option-1">
+          <sd-option value="option-1">Option 1</sd-option>
+          <sd-option value="option-2">Option 2</sd-option>
+          <sd-option value="option-3">Option 3</sd-option>
+        </sd-select>
+      `);
+      input.setCustomValidity('Invalid selection');
+      await input.updateComplete;
+
+      input.reportValidity();
+      await input.updateComplete;
+      await input.updateComplete; // Currently there are two updates in the component
+
+      expect(input.shadowRoot!.querySelector('#invalid-message')!.hasAttribute('hidden')).to.be.false;
+
+      input.setCustomValidity('');
+      await input.updateComplete;
+
+      input.reportValidity();
+      await input.updateComplete;
+      await input.updateComplete; // Currently there are two updates in the component
+
+      expect(input.shadowRoot!.querySelector('#invalid-message')!.hasAttribute('hidden')).to.be.true;
+    });
+
+    it('should show correct icon when calling reportValidity()', async () => {
+      const input = await fixture<SdSelect>(html`
+        <sd-select name="a" value="option-1">
+          <sd-option value="option-1">Option 1</sd-option>
+          <sd-option value="option-2">Option 2</sd-option>
+          <sd-option value="option-3">Option 3</sd-option>
+        </sd-select>
+      `);
+
+      input.setCustomValidity('Invalid selection');
+      await input.updateComplete;
+
+      input.reportValidity();
+      await input.updateComplete;
+      await input.updateComplete; // Currently there are two updates in the component
+
+      expect(input.shadowRoot!.querySelector('[part~="invalid-icon"]')).to.exist;
+      expect(input.shadowRoot!.querySelector('[part~="valid-icon"]')).to.not.exist;
+
+      input.setCustomValidity('');
+      await input.updateComplete;
+
+      input.reportValidity();
+      await input.updateComplete;
+      await input.updateComplete; // Currently there are two updates in the component
+
+      expect(input.shadowRoot!.querySelector('[part~="invalid-icon"]')).to.not.exist;
+      expect(input.shadowRoot!.querySelector('[part~="valid-icon"]')).to.exist;
+    });
+
+    it('should be present in form data when using the form attribute and located outside of a <form>', async () => {
+      const el = await fixture<HTMLFormElement>(html`
+        <div>
+          <form id="f">
+            <sd-button type="submit">Submit</sd-button>
+          </form>
+          <sd-input form="f" name="a" value="1"></sd-input>
+        </div>
+      `);
+      const form = el.querySelector('form')!;
+      const formData = new FormData(form);
+
+      expect(formData.get('a')).to.equal('1');
+    });
   });
 
   describe('when resetting a form', () => {

--- a/packages/components/src/components/select/select.ts
+++ b/packages/components/src/components/select/select.ts
@@ -746,6 +746,7 @@ export default class SdSelect extends SolidElement implements SolidFormControl {
 
   /** Checks for validity and shows the browser's validation message if the control is invalid. */
   reportValidity() {
+    this.formControlController.fakeUserInteraction();
     return this.valueInput.reportValidity();
   }
 
@@ -961,12 +962,18 @@ export default class SdSelect extends SolidElement implements SolidFormControl {
                 : ''}
               ${this.showInvalidStyle
                 ? html`
-                    <sd-icon class=${cx('text-error', iconMarginLeft, iconSize)} library="system" name="risk"></sd-icon>
+                    <sd-icon
+                      part="invalid-icon"
+                      class=${cx('text-error', iconMarginLeft, iconSize)}
+                      library="system"
+                      name="risk"
+                    ></sd-icon>
                   `
                 : ''}
               ${this.showValidStyle
                 ? html`
                     <sd-icon
+                      part="valid-icon"
                       class=${cx('text-success', iconMarginLeft, iconSize)}
                       library="system"
                       name="confirm"

--- a/packages/components/src/internal/form.ts
+++ b/packages/components/src/internal/form.ts
@@ -242,6 +242,11 @@ export class FormControlController implements ReactiveController {
     }
   };
 
+  // This is used by `reportValidity` to show validity state styles and messages without manual user interaction
+  fakeUserInteraction = () => {
+    this.setUserInteracted(this.host, true);
+  };
+
   private reportFormValidity() {
     //
     // Solid form controls work hard to act like regular form controls. They support the Constraint Validation API
@@ -330,7 +335,7 @@ export class FormControlController implements ReactiveController {
     return html`<div
       id="invalid-message"
       class="text-error text-sm mt-2 text-left"
-      part="error-message"
+      part="invalid-message"
       aria-live="polite"
       ?hidden=${!this.host.showInvalidStyle}
     ></div>`;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,6 +195,9 @@ importers:
       normalize.css:
         specifier: ^8.0.1
         version: 8.0.1
+      playwright:
+        specifier: ^1.40.1
+        version: 1.40.1
       plop:
         specifier: ^4.0.0
         version: 4.0.0
@@ -5511,7 +5514,7 @@ packages:
     dependencies:
       '@web/test-runner-core': 0.13.0
       '@web/test-runner-coverage-v8': 0.8.0
-      playwright: 1.39.0
+      playwright: 1.40.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -11723,18 +11726,18 @@ packages:
       find-up: 2.1.0
     dev: true
 
-  /playwright-core@1.39.0:
-    resolution: {integrity: sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==}
+  /playwright-core@1.40.1:
+    resolution: {integrity: sha512-+hkOycxPiV534c4HhpfX6yrlawqVUzITRKwHAmYfmsVreltEl6fAZJ3DPfLMOODw0H3s1Itd6MDCWmP1fl/QvQ==}
     engines: {node: '>=16'}
     hasBin: true
     dev: true
 
-  /playwright@1.39.0:
-    resolution: {integrity: sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==}
+  /playwright@1.40.1:
+    resolution: {integrity: sha512-2eHI7IioIpQ0bS1Ovg/HszsN/XKNwEG1kbzSDDmADpclKc7CyqkHw7Mg2JCz/bbCxg25QUPcjksoMW7JcIFQmw==}
     engines: {node: '>=16'}
     hasBin: true
     dependencies:
-      playwright-core: 1.39.0
+      playwright-core: 1.40.1
     optionalDependencies:
       fsevents: 2.3.2
     dev: true


### PR DESCRIPTION
## Description:
It should not be needed that users interact with an input element to show an error message, if setCustomValidity('an error') and reportValidity() was called. Before that the user needed to interact with the element, to show the error or make it valid.

---

The draft PR currently only contains rough tests, which describe more or less the actual behaviour. Plus a Storybook story was created which shows a demo. (Clicking on a button should directly show the validation.)

## Definition of Reviewable:
*PR notes: Irrelevant elements should be removed.*
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
- [ ] PR is assigned to project board
