### PR TITLE
chore: 🔧 fix failing scrollend event related tests for sd-carousel [skip chromatic]

### DIFF
--- a/packages/components/src/components/carousel/carousel.test.ts
+++ b/packages/components/src/components/carousel/carousel.test.ts
@@ -569,7 +569,7 @@ describe('<sd-carousel>', () => {
         await oneEvent(el.scrollContainer, 'scrollend', false);
         await el.updateComplete;
 
-        // It takes a moment for the scrollend event to be fired
+        // It takes a moment for the scrollend event to be fired.
         await aTimeout(100);
 
         expect(el.scrollContainer).to.have.attribute('aria-busy', 'false');

--- a/packages/components/src/components/carousel/carousel.test.ts
+++ b/packages/components/src/components/carousel/carousel.test.ts
@@ -1,5 +1,5 @@
+import { aTimeout, expect, fixture, html, oneEvent } from '@open-wc/testing';
 import { clickOnElement } from '../../internal/test.js';
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 import sinon from 'sinon';
 import type SdCarousel from './carousel';
 
@@ -570,7 +570,7 @@ describe('<sd-carousel>', () => {
         await el.updateComplete;
 
         // It takes a moment for the scrollend event to be fired
-        await new Promise(resolve => setTimeout(resolve, 100));
+        await aTimeout(100);
 
         expect(el.scrollContainer).to.have.attribute('aria-busy', 'false');
       });

--- a/packages/components/src/components/carousel/carousel.test.ts
+++ b/packages/components/src/components/carousel/carousel.test.ts
@@ -1,7 +1,7 @@
 import { clickOnElement } from '../../internal/test.js';
 import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 import sinon from 'sinon';
-import type SdCarousel from './carousel.js';
+import type SdCarousel from './carousel';
 
 describe('<sd-carousel>', () => {
   it('should render a carousel with default configuration', async () => {
@@ -304,32 +304,31 @@ describe('<sd-carousel>', () => {
           expect(nextButton).to.have.attribute('aria-disabled', 'true');
           expect(el.next).not.to.have.been.called;
         });
-        // TODO: This test times out: https://github.com/solid-design-system/solid/issues/387
-        // describe('and `loop` attribute is provided', () => {
-        //   it('should scroll to the first slide', async () => {
-        //     // Arrange
-        //     const el = await fixture<SdCarousel>(html`
-        //       <sd-carousel variant="dot" loop>
-        //         <sd-carousel-item>Node 1</sd-carousel-item>
-        //         <sd-carousel-item>Node 2</sd-carousel-item>
-        //         <sd-carousel-item>Node 3</sd-carousel-item>
-        //       </sd-carousel>
-        //     `);
-        //     const nextButton: HTMLElement = el.shadowRoot!.querySelector('#carousel__navigation-button--next')!;
-        //     el.goToSlide(2, 'auto');
-        //     await oneEvent(el.scrollContainer, 'scrollend');
-        //     await el.updateComplete;
-        //     // Act
-        //     await clickOnElement(nextButton);
-        //     // wait first scroll to clone
-        //     await oneEvent(el.scrollContainer, 'scrollend');
-        //     // wait scroll to actual item
-        //     await oneEvent(el.scrollContainer, 'scrollend');
-        //     // Assert
-        //     expect(nextButton).to.have.attribute('aria-disabled', 'false');
-        //     expect(el.activeSlide).to.be.equal(0);
-        //   });
-        // });
+        describe('and `loop` attribute is provided', () => {
+          it('should scroll to the first slide', async () => {
+            // Arrange
+            const el = await fixture<SdCarousel>(html`
+              <sd-carousel variant="dot" loop>
+                <sd-carousel-item>Node 1</sd-carousel-item>
+                <sd-carousel-item>Node 2</sd-carousel-item>
+                <sd-carousel-item>Node 3</sd-carousel-item>
+              </sd-carousel>
+            `);
+            const nextButton: HTMLElement = el.shadowRoot!.querySelector('#carousel__navigation-button--next')!;
+            el.goToSlide(2, 'auto');
+            await oneEvent(el.scrollContainer, 'scrollend', false);
+            await el.updateComplete;
+            // Act
+            await clickOnElement(nextButton);
+            // wait first scroll to clone
+            await oneEvent(el.scrollContainer, 'scrollend', false);
+            // wait scroll to actual item
+            await oneEvent(el.scrollContainer, 'scrollend', false);
+            // Assert
+            expect(nextButton).to.have.attribute('aria-disabled', 'false');
+            expect(el.activeSlide).to.be.equal(0);
+          });
+        });
       });
     });
   });
@@ -545,34 +544,36 @@ describe('<sd-carousel>', () => {
       });
     });
 
-    // TODO: This test is failing for Chromium: https://github.com/solid-design-system/solid/issues/387
-    // describe('when scrolling', () => {
-    //   it('should update aria-busy attribute', async () => {
-    //     // Arrange
-    //     const el = await fixture<SdCarousel>(html`
-    //       <sd-carousel variant="dot">
-    //         <sd-carousel-item>Node 1</sd-carousel-item>
-    //         <sd-carousel-item>Node 2</sd-carousel-item>
-    //         <sd-carousel-item>Node 3</sd-carousel-item>
-    //       </sd-carousel>
-    //     `);
+    describe('when scrolling', () => {
+      it('should update aria-busy attribute', async () => {
+        // Arrange
+        const el = await fixture<SdCarousel>(html`
+          <sd-carousel variant="dot">
+            <sd-carousel-item>Node 1</sd-carousel-item>
+            <sd-carousel-item>Node 2</sd-carousel-item>
+            <sd-carousel-item>Node 3</sd-carousel-item>
+          </sd-carousel>
+        `);
 
-    //     await el.updateComplete;
+        await el.updateComplete;
 
-    //     expect(el.scrollContainer).to.have.attribute('aria-busy', 'false');
+        expect(el.scrollContainer).to.have.attribute('aria-busy', 'false');
 
-    //     // Act
-    //     el.goToSlide(2, 'smooth');
-    //     await oneEvent(el.scrollContainer, 'scroll');
-    //     await el.updateComplete;
+        // Act
+        el.goToSlide(2, 'smooth');
+        await oneEvent(el.scrollContainer, 'scroll', false);
+        await el.updateComplete;
+        // Assert
+        expect(el.scrollContainer).to.have.attribute('aria-busy', 'true');
 
-    //     // Assert
-    //     expect(el.scrollContainer).to.have.attribute('aria-busy', 'true');
+        await oneEvent(el.scrollContainer, 'scrollend', false);
+        await el.updateComplete;
 
-    //     await oneEvent(el.scrollContainer, 'scrollend');
-    //     await el.updateComplete;
-    //     expect(el.scrollContainer).to.have.attribute('aria-busy', 'false');
-    //   });
-    // });
+        // It takes a moment for the scrollend event to be fired
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        expect(el.scrollContainer).to.have.attribute('aria-busy', 'false');
+      });
+    });
   });
 });


### PR DESCRIPTION
## Description:
Closes #387. I noticed it takes a moment for the `aria-busy` attribute to be updated after scrollend is fired. I added a 100ms timeout to account for that gap.

https://github.com/solid-design-system/solid/assets/63849626/a0d8b7ca-1883-4a24-90ef-667648c6daca

 

## Definition of Reviewable:
*PR notes: Irrelevant elements should be removed.*
- [x] E2E tests (features, a11y, bug fixes) are created/updated
- [x] relevant tickets are linked
- [x] PR is assigned to project board
