### PR TITLE
fix: output of color-calculation.js for white and black color

### DIFF
--- a/packages/theming/src/color-calculation.js
+++ b/packages/theming/src/color-calculation.js
@@ -169,7 +169,7 @@ export const calculateColorsAsCss = (colors, theme, useNormalizedLuminanceMap, u
   Object.keys(colors).forEach(type => {
     if (type === 'black' || type === 'white') {
       // Add the color directly without generating shades
-      allTokens += `  --sd-color-${type}: ${colors[type]};\n`;
+      allTokens += `  --sd-color-${type}: ${chroma(colors[type]).rgb().join(' ')};\n`;
     } else {
       allTokens += calculateColorsForType(type, theme, colors, useNormalizedLuminanceMap, useForcedShades);
     }


### PR DESCRIPTION
## Description:

currently the white and black color doesn't get transforemd from hex to rgb value.
![grafik](https://github.com/solid-design-system/solid/assets/54807480/ce0d7540-2d50-4158-bc8b-ad444a7f1ac5)


This pr converts the white and black color to the rbg format like the other colors


## Definition of Reviewable:
*PR notes: Irrelevant elements should be removed.*
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
- [ ] PR is assigned to project board
