### PR TITLE
fix: remove unneeded gradient horizontal

### DIFF
--- a/packages/tokens/src/tokens.json
+++ b/packages/tokens/src/tokens.json
@@ -1677,46 +1677,6 @@
         "type": "color",
         "description": "Used in sd-media-teaser"
       },
-      "horizontal-transparent-black|75": {
-        "value": "linear-gradient(90deg, rgba({black}, 0.75) 100%, rgba({black}, 0.4) 50%, rgba({black}, 0) 25% )",
-        "type": "color",
-        "description": "Used in sd-quote"
-      },
-      "horizontal-black|75-transparent": {
-        "value": "linear-gradient(270deg, rgba({black}, 0) 25%, rgba({black}, 0.4) 50%, rgba({black}, 0.75) 100%)",
-        "type": "color",
-        "description": "Used in sd-quote"
-      },
-      "horizontal-transparent-white|80": {
-        "value": "linear-gradient(90deg, rgba({white}, 0.8) 100%, rgba({white}, 0.4) 50%, rgba({white}, 0) 25% )",
-        "type": "color",
-        "description": "Used in sd-quote"
-      },
-      "horizontal-white|80-transparent": {
-        "value": "linear-gradient(270deg, rgba({white}, 0) 25%, rgba({white}, 0.4) 50%, rgba({white}, 0.8) 100%)",
-        "type": "color",
-        "description": "Used in sd-quote"
-      },
-      "horizontal-black|65-black|80": {
-        "value": "linear-gradient(90deg, rgba({black}, 0.65) 50%, rgba({black}, 0.80) 100%)",
-        "type": "color",
-        "description": "Used in sd-quote (mobile)"
-      },
-      "horizontal-black|80-black|65": {
-        "value": "linear-gradient(270deg, rgba({black}, 0.65) 50%, rgba({black}, 0.80) 100%)",
-        "type": "color",
-        "description": "Used in sd-quote (mobile)"
-      },
-      "horizontal-white|80-white|65": {
-        "value": "linear-gradient(270deg, rgba({white},0.8) 0%, rgba({white},0.65) 100%)",
-        "type": "color",
-        "description": "Used in sd-quote (mobile)"
-      },
-      "horizontal-white|65-white|80": {
-        "value": "linear-gradient(90deg, rgba({white},0.8) 0%, rgba({white},0.65) 100%)",
-        "type": "color",
-        "description": "Used in sd-quote (mobile)"
-      },
       "horizontal-transparent-white": {
         "value": "linear-gradient(90deg, rgba({white}, 0) 0%, rgba({white}, 1) 80%, rgba({white}, 1) 100%)",
         "type": "color",


### PR DESCRIPTION
## Description:
 due to the deprecation of sd-quote [#572](https://github.com/solid-design-system/solid/issues/572), all gradients applied for this component should be deprecated: 
 -gradient.horizontal-transparent-black|75
 -gradient.horizontal-black|75-transparent
 -gradient.horizontal-transparent-white|80
 -gradient.horizontal-white|80-transparent
 -gradient.horizontal-black|80-black|65
 -gradient.horizontal-black|65-black|80

Todos after FE's approval:
 - [ ] release note
 - [ ] update figma native styles
