### PR TITLE
feat: ✨ add sd container triangle property

### DIFF
--- a/packages/components/src/styles/container/container.css
+++ b/packages/components/src/styles/container/container.css
@@ -27,61 +27,84 @@
   &--triangle-right::before,
   &--triangle-bottom::before,
   &--triangle-left::before {
-    @apply absolute block content-[''] border-solid border-transparent;
+    @apply absolute block content-[''] border-solid border-transparent border-[14px];
   }
 
   &--triangle-top::before {
-    @apply left-[calc(50%-14px)] top-0 border-[14px] border-t-[var(--triangle-background)];
+    @apply left-[calc(50%-14px)] top-0 border-t-[var(--triangle-background)];
   }
-
   &--triangle-right::before {
-    @apply top-[calc(50%-14px)] right-0 border-[14px] border-r-[var(--triangle-background)];
+    @apply top-[calc(50%-14px)] right-0 border-r-[var(--triangle-background)];
   }
-
   &--triangle-bottom::before {
-    @apply left-[calc(50%-14px)] bottom-0 border-[14px] border-b-[var(--triangle-background)];
+    @apply left-[calc(50%-14px)] bottom-0 border-b-[var(--triangle-background)];
   }
-
   &--triangle-left::before {
-    @apply top-[calc(50%-14px)] left-0 border-[14px] border-l-[var(--triangle-background)];
+    @apply top-[calc(50%-14px)] left-0 border-l-[var(--triangle-background)];
   }
 
-  &--triangle-top-border::before,
-  &--triangle-right-border::before,
-  &--triangle-bottom-border::before,
-  &--triangle-left-border::before {
-    @apply absolute block content-[''] border-transparent border-solid;
+  &--triangle-top-border,
+  &--triangle-right-border,
+  &--triangle-bottom-border,
+  &--triangle-left-border {
+    &::after,
+    &::before {
+      @apply absolute block content-[''] border-solid border-transparent;
+    }
+    &::after {
+      @apply border-[14px];
+    }
+    &::before {
+      @apply border-[15px];
+    }
   }
 
-  &--triangle-top-border::before {
-    @apply left-[calc(50%-15px)] border-[15px] border-t-neutral-400;
+  &--triangle-top-border {
+    &::after,
+    &::before {
+      @apply -top-[1px];
+    }
+    &::before {
+      @apply left-[calc(50%-15px)] border-t-neutral-400;
+    }
+    &::after {
+      @apply left-[calc(50%-14px)] border-t-[var(--triangle-background)];
+    }
   }
-
-  &--triangle-top-border::after {
-    @apply left-[calc(50%-14px)] border-[14px] border-t-[var(--triangle-background)];
+  &--triangle-right-border {
+    &::after,
+    &::before {
+      @apply -right-[1px];
+    }
+    &::before {
+      @apply top-[calc(50%-15px)] border-r-neutral-400;
+    }
+    &::after {
+      @apply top-[calc(50%-14px)] border-r-[var(--triangle-background)];
+    }
   }
-
-  &--triangle-right-border::before {
-    @apply top-[calc(50%-15px)] border-[15px] border-r-neutral-400;
+  &--triangle-bottom-border {
+    &::after,
+    &::before {
+      @apply -bottom-[1px];
+    }
+    &::before {
+      @apply left-[calc(50%-15px)] border-b-neutral-400;
+    }
+    &::after {
+      @apply left-[calc(50%-14px)] border-b-[var(--triangle-background)];
+    }
   }
-
-  &--triangle-right-border::after {
-    @apply top-[calc(50%-14px)] border-[14px] border-r-[var(--triangle-background)];
-  }
-
-  &--triangle-bottom-border::before {
-    @apply left-[calc(50%-15px)] border-[15px] border-b-neutral-400;
-  }
-
-  &--triangle-bottom-border::after {
-    @apply left-[calc(50%-14px)] border-[14px] border-b-[var(--triangle-background)];
-  }
-
-  &--triangle-left-border::before {
-    @apply top-[calc(50%-15px)] border-[15px] border-l-neutral-400;
-  }
-
-  &--triangle-left-border::after {
-    @apply top-[calc(50%-14px)] border-[14px] border-l-[var(--triangle-background)];
+  &--triangle-left-border {
+    &::after,
+    &::before {
+      @apply -left-[1px];
+    }
+    &::before {
+      @apply top-[calc(50%-15px)] border-l-neutral-400;
+    }
+    &::after {
+      @apply top-[calc(50%-14px)] border-l-[var(--triangle-background)];
+    }
   }
 }

--- a/packages/components/src/styles/container/container.css
+++ b/packages/components/src/styles/container/container.css
@@ -38,4 +38,36 @@
   &--triangle-left::before {
     @apply absolute block top-[calc(50%-15px)] left-0 content-[''] border-solid border-transparent border-[15px] border-l-[var(--triangle-background)];
   }
+
+  &--triangle-top-border::after {
+    @apply absolute block left-[calc(50%-15px)] -top-[1px] content-[''] border-transparent border-solid border-[15px] border-t-[var(--triangle-background)];
+  }
+
+  &--triangle-top-border::before {
+    @apply absolute block left-[calc(50%-16px)] -top-[1px] content-[''] border-transparent border-solid border-[16px] border-t-neutral-400;
+  }
+
+  &--triangle-right-border::after {
+    @apply absolute block top-[calc(50%-15px)] -right-[1px] content-[''] border-transparent border-solid border-[15px] border-r-[var(--triangle-background)];
+  }
+
+  &--triangle-right-border::before {
+    @apply absolute block top-[calc(50%-16px)] -right-[1px] content-[''] border-transparent border-solid border-[16px] border-r-neutral-400;
+  }
+
+  &--triangle-bottom-border::after {
+    @apply absolute block left-[calc(50%-15px)] -bottom-[1px] content-[''] border-transparent border-solid border-[15px] border-b-[var(--triangle-background)];
+  }
+
+  &--triangle-bottom-border::before {
+    @apply absolute block left-[calc(50%-16px)] -bottom-[1px] content-[''] border-transparent border-solid border-[16px] border-b-neutral-400;
+  }
+
+  &--triangle-left-border::after {
+    @apply absolute block top-[calc(50%-15px)] -left-[1px] content-[''] border-transparent border-solid border-[15px] border-l-[var(--triangle-background)];
+  }
+
+  &--triangle-left-border::before {
+    @apply absolute block top-[calc(50%-16px)] -left-[1px] content-[''] border-transparent border-solid border-[16px] border-l-neutral-400;
+  }
 }

--- a/packages/components/src/styles/container/container.css
+++ b/packages/components/src/styles/container/container.css
@@ -24,19 +24,19 @@
   --triangle-background: white;
 
   &--triangle-top::before {
-    @apply absolute block left-[calc(50%-15px)] top-0 content-[''] border-solid border-transparent border-[15px] border-t-[var(--triangle-background)];
+    @apply absolute block left-[calc(50%-14px)] top-0 content-[''] border-solid border-transparent border-[14px] border-t-[var(--triangle-background)];
   }
 
   &--triangle-right::before {
-    @apply absolute block top-[calc(50%-15px)] right-0 content-[''] border-solid border-transparent border-[15px] border-r-[var(--triangle-background)];
+    @apply absolute block top-[calc(50%-14px)] right-0 content-[''] border-solid border-transparent border-[14px] border-r-[var(--triangle-background)];
   }
 
   &--triangle-bottom::before {
-    @apply absolute block left-[calc(50%-15px)] bottom-0 content-[''] border-solid border-transparent border-[15px] border-b-[var(--triangle-background)];
+    @apply absolute block left-[calc(50%-14px)] bottom-0 content-[''] border-solid border-transparent border-[14px] border-b-[var(--triangle-background)];
   }
 
   &--triangle-left::before {
-    @apply absolute block top-[calc(50%-15px)] left-0 content-[''] border-solid border-transparent border-[15px] border-l-[var(--triangle-background)];
+    @apply absolute block top-[calc(50%-14px)] left-0 content-[''] border-solid border-transparent border-[14px] border-l-[var(--triangle-background)];
   }
 
   &--triangle-top-border {
@@ -46,11 +46,11 @@
     }
 
     &::before {
-      @apply left-[calc(50%-16px)] border-[16px] border-t-neutral-400;
+      @apply left-[calc(50%-15px)] border-[15px] border-t-neutral-400;
     }
 
     &::after {
-      @apply left-[calc(50%-15px)] border-[15px] border-t-[var(--triangle-background)];
+      @apply left-[calc(50%-14px)] border-[14px] border-t-[var(--triangle-background)];
     }
   }
 
@@ -61,11 +61,11 @@
     }
 
     &::before {
-      @apply top-[calc(50%-16px)] border-[16px] border-r-neutral-400;
+      @apply top-[calc(50%-15px)] border-[15px] border-r-neutral-400;
     }
 
     &::after {
-      @apply top-[calc(50%-15px)] border-[15px] border-r-[var(--triangle-background)];
+      @apply top-[calc(50%-14px)] border-[14px] border-r-[var(--triangle-background)];
     }
   }
 
@@ -76,11 +76,11 @@
     }
 
     &::before {
-      @apply left-[calc(50%-16px)] border-[16px] border-b-neutral-400;
+      @apply left-[calc(50%-15px)] border-[15px] border-b-neutral-400;
     }
 
     &::after {
-      @apply left-[calc(50%-15px)] border-[15px] border-b-[var(--triangle-background)];
+      @apply left-[calc(50%-14px)] border-[14px] border-b-[var(--triangle-background)];
     }
   }
 
@@ -91,11 +91,11 @@
     }
 
     &::before {
-      @apply top-[calc(50%-16px)] border-[16px] border-l-neutral-400;
+      @apply top-[calc(50%-15px)] border-[15px] border-l-neutral-400;
     }
 
     &::after {
-      @apply top-[calc(50%-15px)] border-[15px] border-l-[var(--triangle-background)];
+      @apply top-[calc(50%-14px)] border-[14px] border-l-[var(--triangle-background)];
     }
   }
 }

--- a/packages/components/src/styles/container/container.css
+++ b/packages/components/src/styles/container/container.css
@@ -23,79 +23,88 @@
 
   --triangle-background: white;
 
-  &--triangle-top::before {
-    @apply absolute block left-[calc(50%-14px)] top-0 content-[''] border-solid border-transparent border-[14px] border-t-[var(--triangle-background)];
-  }
-
-  &--triangle-right::before {
-    @apply absolute block top-[calc(50%-14px)] right-0 content-[''] border-solid border-transparent border-[14px] border-r-[var(--triangle-background)];
-  }
-
-  &--triangle-bottom::before {
-    @apply absolute block left-[calc(50%-14px)] bottom-0 content-[''] border-solid border-transparent border-[14px] border-b-[var(--triangle-background)];
-  }
-
+  &--triangle-top::before,
+  &--triangle-right::before,
+  &--triangle-bottom::before,
   &--triangle-left::before {
-    @apply absolute block top-[calc(50%-14px)] left-0 content-[''] border-solid border-transparent border-[14px] border-l-[var(--triangle-background)];
+    @apply absolute block content-[''] border-solid border-transparent border-[14px];
+  }
+
+  &--triangle-top::before {
+    @apply left-[calc(50%-14px)] top-0 border-t-[var(--triangle-background)];
+  }
+  &--triangle-right::before {
+    @apply top-[calc(50%-14px)] right-0 border-r-[var(--triangle-background)];
+  }
+  &--triangle-bottom::before {
+    @apply left-[calc(50%-14px)] bottom-0 border-b-[var(--triangle-background)];
+  }
+  &--triangle-left::before {
+    @apply top-[calc(50%-14px)] left-0 border-l-[var(--triangle-background)];
+  }
+
+  &--triangle-top-border,
+  &--triangle-right-border,
+  &--triangle-bottom-border,
+  &--triangle-left-border {
+    &::after,
+    &::before {
+      @apply absolute block content-[''] border-solid border-transparent;
+    }
+    &::after {
+      @apply border-[14px];
+    }
+    &::before {
+      @apply border-[15px];
+    }
   }
 
   &--triangle-top-border {
     &::after,
     &::before {
-      @apply absolute block -top-[1px] content-[''] border-transparent border-solid;
+      @apply -top-[1px];
     }
-
     &::before {
-      @apply left-[calc(50%-15px)] border-[15px] border-t-neutral-400;
+      @apply left-[calc(50%-15px)] border-t-neutral-400;
     }
-
     &::after {
-      @apply left-[calc(50%-14px)] border-[14px] border-t-[var(--triangle-background)];
+      @apply left-[calc(50%-14px)] border-t-[var(--triangle-background)];
     }
   }
-
   &--triangle-right-border {
     &::after,
     &::before {
-      @apply absolute block -right-[1px] content-[''] border-transparent border-solid;
+      @apply -right-[1px];
     }
-
     &::before {
-      @apply top-[calc(50%-15px)] border-[15px] border-r-neutral-400;
+      @apply top-[calc(50%-15px)] border-r-neutral-400;
     }
-
     &::after {
-      @apply top-[calc(50%-14px)] border-[14px] border-r-[var(--triangle-background)];
+      @apply top-[calc(50%-14px)] border-r-[var(--triangle-background)];
     }
   }
-
   &--triangle-bottom-border {
     &::after,
     &::before {
-      @apply absolute block -bottom-[1px] content-[''] border-transparent border-solid;
+      @apply -bottom-[1px];
     }
-
     &::before {
-      @apply left-[calc(50%-15px)] border-[15px] border-b-neutral-400;
+      @apply left-[calc(50%-15px)] border-b-neutral-400;
     }
-
     &::after {
-      @apply left-[calc(50%-14px)] border-[14px] border-b-[var(--triangle-background)];
+      @apply left-[calc(50%-14px)] border-b-[var(--triangle-background)];
     }
   }
-
   &--triangle-left-border {
     &::after,
     &::before {
-      @apply absolute block -left-[1px] content-[''] border-transparent border-solid;
+      @apply -left-[1px];
     }
-
     &::before {
-      @apply top-[calc(50%-15px)] border-[15px] border-l-neutral-400;
+      @apply top-[calc(50%-15px)] border-l-neutral-400;
     }
-
     &::after {
-      @apply top-[calc(50%-14px)] border-[14px] border-l-[var(--triangle-background)];
+      @apply top-[calc(50%-14px)] border-l-[var(--triangle-background)];
     }
   }
 }

--- a/packages/components/src/styles/container/container.css
+++ b/packages/components/src/styles/container/container.css
@@ -39,35 +39,63 @@
     @apply absolute block top-[calc(50%-15px)] left-0 content-[''] border-solid border-transparent border-[15px] border-l-[var(--triangle-background)];
   }
 
-  &--triangle-top-border::after {
-    @apply absolute block left-[calc(50%-15px)] -top-[1px] content-[''] border-transparent border-solid border-[15px] border-t-[var(--triangle-background)];
+  &--triangle-top-border {
+    &::after,
+    &::before {
+      @apply absolute block -top-[1px] content-[''] border-transparent border-solid;
+    }
+
+    &::before {
+      @apply left-[calc(50%-16px)] border-[16px] border-t-neutral-400;
+    }
+
+    &::after {
+      @apply left-[calc(50%-15px)] border-[15px] border-t-[var(--triangle-background)];
+    }
   }
 
-  &--triangle-top-border::before {
-    @apply absolute block left-[calc(50%-16px)] -top-[1px] content-[''] border-transparent border-solid border-[16px] border-t-neutral-400;
+  &--triangle-right-border {
+    &::after,
+    &::before {
+      @apply absolute block -right-[1px] content-[''] border-transparent border-solid;
+    }
+
+    &::before {
+      @apply top-[calc(50%-16px)] border-[16px] border-r-neutral-400;
+    }
+
+    &::after {
+      @apply top-[calc(50%-15px)] border-[15px] border-r-[var(--triangle-background)];
+    }
   }
 
-  &--triangle-right-border::after {
-    @apply absolute block top-[calc(50%-15px)] -right-[1px] content-[''] border-transparent border-solid border-[15px] border-r-[var(--triangle-background)];
+  &--triangle-bottom-border {
+    &::after,
+    &::before {
+      @apply absolute block -bottom-[1px] content-[''] border-transparent border-solid;
+    }
+
+    &::before {
+      @apply left-[calc(50%-16px)] border-[16px] border-b-neutral-400;
+    }
+
+    &::after {
+      @apply left-[calc(50%-15px)] border-[15px] border-b-[var(--triangle-background)];
+    }
   }
 
-  &--triangle-right-border::before {
-    @apply absolute block top-[calc(50%-16px)] -right-[1px] content-[''] border-transparent border-solid border-[16px] border-r-neutral-400;
-  }
+  &--triangle-left-border {
+    &::after,
+    &::before {
+      @apply absolute block -left-[1px] content-[''] border-transparent border-solid;
+    }
 
-  &--triangle-bottom-border::after {
-    @apply absolute block left-[calc(50%-15px)] -bottom-[1px] content-[''] border-transparent border-solid border-[15px] border-b-[var(--triangle-background)];
-  }
+    &::before {
+      @apply top-[calc(50%-16px)] border-[16px] border-l-neutral-400;
+    }
 
-  &--triangle-bottom-border::before {
-    @apply absolute block left-[calc(50%-16px)] -bottom-[1px] content-[''] border-transparent border-solid border-[16px] border-b-neutral-400;
-  }
-
-  &--triangle-left-border::after {
-    @apply absolute block top-[calc(50%-15px)] -left-[1px] content-[''] border-transparent border-solid border-[15px] border-l-[var(--triangle-background)];
-  }
-
-  &--triangle-left-border::before {
-    @apply absolute block top-[calc(50%-16px)] -left-[1px] content-[''] border-transparent border-solid border-[16px] border-l-neutral-400;
+    &::after {
+      @apply top-[calc(50%-15px)] border-[15px] border-l-[var(--triangle-background)];
+    }
   }
 }

--- a/packages/components/src/styles/container/container.css
+++ b/packages/components/src/styles/container/container.css
@@ -1,5 +1,5 @@
 .sd-container {
-  @apply bg-neutral-100 px-10 py-8;
+  @apply bg-neutral-100 px-10 py-8 relative;
 
   &--variant-primary-100 {
     @apply bg-primary-100;
@@ -19,5 +19,21 @@
 
   &--padding-sm {
     @apply px-6 py-4;
+  }
+
+  &--triangle-top::before {
+    @apply absolute block left-[calc(50%-15px)] top-0 content-[''] border-solid border-transparent border-[15px] border-t-white;
+  }
+
+  &--triangle-right::before {
+    @apply absolute block top-[calc(50%-15px)] right-0 content-[''] border-solid border-transparent border-[15px] border-r-white;
+  }
+
+  &--triangle-bottom::before {
+    @apply absolute block left-[calc(50%-15px)] bottom-0 content-[''] border-solid border-transparent border-[15px] border-b-white;
+  }
+
+  &--triangle-left::before {
+    @apply absolute block top-[calc(50%-15px)] left-0 content-[''] border-solid border-transparent border-[15px] border-l-white;
   }
 }

--- a/packages/components/src/styles/container/container.css
+++ b/packages/components/src/styles/container/container.css
@@ -21,19 +21,21 @@
     @apply px-6 py-4;
   }
 
+  --triangle-background: white;
+
   &--triangle-top::before {
-    @apply absolute block left-[calc(50%-15px)] top-0 content-[''] border-solid border-transparent border-[15px] border-t-white;
+    @apply absolute block left-[calc(50%-15px)] top-0 content-[''] border-solid border-transparent border-[15px] border-t-[var(--triangle-background)];
   }
 
   &--triangle-right::before {
-    @apply absolute block top-[calc(50%-15px)] right-0 content-[''] border-solid border-transparent border-[15px] border-r-white;
+    @apply absolute block top-[calc(50%-15px)] right-0 content-[''] border-solid border-transparent border-[15px] border-r-[var(--triangle-background)];
   }
 
   &--triangle-bottom::before {
-    @apply absolute block left-[calc(50%-15px)] bottom-0 content-[''] border-solid border-transparent border-[15px] border-b-white;
+    @apply absolute block left-[calc(50%-15px)] bottom-0 content-[''] border-solid border-transparent border-[15px] border-b-[var(--triangle-background)];
   }
 
   &--triangle-left::before {
-    @apply absolute block top-[calc(50%-15px)] left-0 content-[''] border-solid border-transparent border-[15px] border-l-white;
+    @apply absolute block top-[calc(50%-15px)] left-0 content-[''] border-solid border-transparent border-[15px] border-l-[var(--triangle-background)];
   }
 }

--- a/packages/components/src/styles/container/container.declaration.ts
+++ b/packages/components/src/styles/container/container.declaration.ts
@@ -19,7 +19,7 @@ export default {
     },
     {
       name: 'sd-container--triangle-...',
-      options: ['top, right, bottom, left'],
+      options: ['top', 'right', 'bottom', 'left'],
       description:
         'Defines an optional triangle cut-out for sd-container. This allows for an indentation resembling an arrow on any side of the container. CSS Property `triangle-background` defines the background color of the cut-out.'
     }

--- a/packages/components/src/styles/container/container.declaration.ts
+++ b/packages/components/src/styles/container/container.declaration.ts
@@ -16,6 +16,12 @@ export default {
       name: 'sd-container--padding-...',
       options: ['sm'],
       description: 'Defines the padding of sd-container. This makes it adaptable to both small and large screens.'
+    },
+    {
+      name: 'sd-container--triangle-...',
+      options: ['top, right, bottom, left'],
+      description:
+        'Defines an optional triangle cut-out for sd-container. This allows for an indentation resembling an arrow on any side of the container. CSS Property `triangle-background` defines the background color of the cut-out.'
     }
   ]
 } satisfies Style;

--- a/packages/components/src/styles/container/container.stories.ts
+++ b/packages/components/src/styles/container/container.stories.ts
@@ -184,7 +184,7 @@ export const TriangleBorder = {
             type: 'attribute',
             name: 'sd-container--triangle',
             values: [
-              'sd-container--triangle-top sd-container--triangle-top-border',
+              'sd-container--triangle-top-border',
               'sd-container--triangle-right-border',
               'sd-container--triangle-bottom-border',
               'sd-container--triangle-left-border'

--- a/packages/components/src/styles/container/container.stories.ts
+++ b/packages/components/src/styles/container/container.stories.ts
@@ -141,11 +141,12 @@ export const CustomPadding = {
 export const TrianglePosition = {
   parameters: {
     controls: {
-      exclude: ['sd-container--triangle-...']
+      exclude: ['sd-container--triangle-...', 'sd-container--variant-...']
     }
   },
   render: (args: any) => {
     return html` ${generateTemplate({
+      constants: [{ type: 'attribute', name: 'sd-container--variant-...', value: 'primary' }],
       axis: {
         y: [
           {
@@ -212,8 +213,6 @@ export const TriangleColor = {
   },
   render: (args: any) => {
     const { 'sd-container--padding-...-attr': paddingAttr } = args;
-
-    console.log(paddingAttr);
 
     return html`
       <div class="bg-primary p-4">

--- a/packages/components/src/styles/container/container.stories.ts
+++ b/packages/components/src/styles/container/container.stories.ts
@@ -184,7 +184,7 @@ export const TriangleBorder = {
             type: 'attribute',
             name: 'sd-container--triangle',
             values: [
-              'sd-container--triangle-top-border',
+              'sd-container--triangle-top sd-container--triangle-top-border',
               'sd-container--triangle-right-border',
               'sd-container--triangle-bottom-border',
               'sd-container--triangle-left-border'

--- a/packages/components/src/styles/container/container.stories.ts
+++ b/packages/components/src/styles/container/container.stories.ts
@@ -133,3 +133,34 @@ export const CustomPadding = {
     });
   }
 };
+
+/**
+ * You can add a triangle indentation to the container using the `--triangle-` class appended with one of the following positions 'top', 'right', 'bottom', 'left' (e.g. `sd-container--triangle-top`).
+ */
+
+export const Triangle = {
+  parameters: {
+    controls: {
+      exclude: ['sd-container--triangle-...']
+    }
+  },
+  render: (args: any) => {
+    return html` ${generateTemplate({
+      axis: {
+        y: [
+          {
+            type: 'attribute',
+            name: 'sd-container--triangle',
+            values: [
+              'sd-container--triangle-top',
+              'sd-container--triangle-right',
+              'sd-container--triangle-bottom',
+              'sd-container--triangle-left'
+            ]
+          }
+        ]
+      },
+      args
+    })}`;
+  }
+};

--- a/packages/components/src/styles/container/container.stories.ts
+++ b/packages/components/src/styles/container/container.stories.ts
@@ -206,6 +206,7 @@ export const TriangleBorder = {
  */
 
 export const TriangleColor = {
+  name: 'Sample: Triangle Color',
   parameters: {
     controls: {
       exclude: ['sd-container--variant-...', 'sd-container--triangle-...']

--- a/packages/components/src/styles/container/container.stories.ts
+++ b/packages/components/src/styles/container/container.stories.ts
@@ -138,7 +138,7 @@ export const CustomPadding = {
  * You can add a triangle indentation to the container using the `--triangle-` class appended with one of the following positions 'top', 'right', 'bottom', 'left' (e.g. `sd-container--triangle-top`).
  */
 
-export const Triangle = {
+export const TrianglePosition = {
   parameters: {
     controls: {
       exclude: ['sd-container--triangle-...']
@@ -162,5 +162,68 @@ export const Triangle = {
       },
       args
     })}`;
+  }
+};
+
+/**
+ * For the `sd-container--variant-border-neutral-400`, an alternate set of classes must be used to create a triangle with a border.
+ */
+
+export const TriangleBorder = {
+  parameters: {
+    controls: {
+      exclude: ['sd-container--variant-...', 'sd-container--triangle-...']
+    }
+  },
+  render: (args: any) => {
+    return html` ${generateTemplate({
+      constants: [{ type: 'attribute', name: 'sd-container--variant-...', value: 'border-neutral-400' }],
+      axis: {
+        y: [
+          {
+            type: 'attribute',
+            name: 'sd-container--triangle',
+            values: [
+              'sd-container--triangle-top-border',
+              'sd-container--triangle-right-border',
+              'sd-container--triangle-bottom-border',
+              'sd-container--triangle-left-border'
+            ]
+          }
+        ]
+      },
+      args
+    })}`;
+  }
+};
+
+/**
+ * You can set the color of the triangle cut-out using the `--triangle-background` CSS property. CSS variables can be set either with an inline style: `style="--triangle-background: rgb(var(--sd-color-primary-600, 0 53 142) / 1);"` or a custom class:
+ * `.custom-sd-container {
+    --triangle-background: rgb(var(--sd-color-primary-600, 0 53 142) / 1);
+  }`
+ */
+
+export const TriangleColor = {
+  parameters: {
+    controls: {
+      exclude: ['sd-container--variant-...', 'sd-container--triangle-...']
+    }
+  },
+  render: (args: any) => {
+    const { 'sd-container--padding-...-attr': paddingAttr } = args;
+
+    console.log(paddingAttr);
+
+    return html`
+      <div class="bg-primary p-4">
+        <div
+          class=${`sd-container sd-container--variant-white sd-container--triangle-top sd-container--padding-${paddingAttr}`}
+          style="--triangle-background: rgb(var(--sd-color-primary-600, 0 53 142) / 1);"
+        >
+          <div class="slot slot--border slot--text h-12">Default slot</div>
+        </div>
+      </div>
+    `;
   }
 };


### PR DESCRIPTION
## Description:
closes #737 

The ticket defines a custom css property "triangle-background" which sets the background color of the triangle cut out.  I don't see another "style" that demonstrates the use of a "css property" (I know for components this can be documented in the comment block at the top of the component file), so I am not sure how to document that properly and include it in the Triangle story.  Please advise.

## Definition of Reviewable:
*PR notes: Irrelevant elements should be removed.*
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
