### PR TITLE
fix: adjusting vertical-transparent-white token + deprecating vertical-white-transparent

### DIFF
--- a/packages/tokens/src/tokens.json
+++ b/packages/tokens/src/tokens.json
@@ -1612,13 +1612,8 @@
         "type": "color",
         "description": "Used in sd-teaser-full-image, sd-flashcard"
       },
-      "vertical-transparent-white": {
-        "value": "linear-gradient(180deg, rgba({white}, 0) 0%, rgba({white}, 1) 80%, rgba({white}, 1) 100%)",
-        "type": "color",
-        "description": "Used in sd-expandable"
-      },
       "vertical-white-transparent": {
-        "value": "linear-gradient(0deg, rgba({white}, 0) 0%, rgba({white}, 1) 80%, rgba({white}, 1) 100%)",
+        "value": "linear-gradient(0deg, rgba({white}, 0) 5%, rgba({white}, 1) 20%, rgba({white}, 1) 100%)",
         "type": "color",
         "description": "Used in sd-expandable"
       },
@@ -2011,7 +2006,6 @@
         "background.transparent.white|80": "S:d129ecc47b93fe233efab250b3d714fb8246ab72,",
         "background.transparent.white|90": "S:73b805dfc0eb6adde50ab61895c200d622ee9ad2,",
         "gradient.vertical-transparent-primary": "S:f9b8351a69146a1b56c484b6fb50e685bb8c1850,",
-        "gradient.vertical-transparent-white": "S:ca6e6121ad40521e625c346e9917995c4d8c73b2,",
         "background.transparent.neutral-100|80": "S:72e0c2d239612a7303dcb6d9f4701d30ee8cd8ca,",
         "background.transparent.neutral-100|90": "S:4f252362ec4e912b31f17d1b413c3ece08648a6c,",
         "background.transparent.neutral-800|90": "S:ed86daba87d3fb153b61ebfee3c18e5bbdb72cfa,",


### PR DESCRIPTION
## Description:
following #300 00
adjusting gradient tokens due to change in build from color gradient fill to masking gradient fill. 
vertical-transparent-white token is adjusted and kept for sd-expandable
vertical-white-transparent is deprecated

## Definition of Reviewable:
*PR notes: Irrelevant elements should be removed.*
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [x] relevant tickets are linked