### PR TITLE
docs: 📚 add sd-tab-group samples that do not show the custom css & remove deprecated css properties

### DIFF
--- a/packages/components/src/components/tab-group/tab-group.stories.ts
+++ b/packages/components/src/components/tab-group/tab-group.stories.ts
@@ -6,7 +6,6 @@ const { overrideArgs } = storybookHelpers('sd-tab-group');
 const { generateTemplate } = storybookTemplate('sd-tab-group');
 import { userEvent } from '@storybook/testing-library';
 import { waitUntil } from '@open-wc/testing-helpers';
-import { withActions } from '@storybook/addon-actions/decorator';
 
 function generateTabsAndPanels(
   startIndex: number,
@@ -31,7 +30,17 @@ export default {
     value: generateTabsAndPanels(1, 5)
   }),
   argTypes,
-  decorators: [withActions] as any
+  decorators: [
+    (story: () => typeof html) => html`
+      <style>
+        td.template {
+          display: block !important;
+          width: 500px;
+        }
+      </style>
+      ${story()}
+    `
+  ]
 };
 
 /**
@@ -65,18 +74,7 @@ export const TabVariants = {
         args
       })}
     `;
-  },
-  decorators: [
-    (story: () => typeof html) => html`
-      <style>
-        td.template {
-          display: block !important;
-          width: 500px;
-        }
-      </style>
-      ${story()}
-    `
-  ]
+  }
 };
 
 /**
@@ -84,7 +82,6 @@ export const TabVariants = {
  */
 
 export const Scrollable = {
-  // parameters: { ...parameters, docs: { story: { inline: false, height: '550px' } } },
   render: (args: any) => {
     return html`
       ${generateTemplate({

--- a/packages/components/src/components/tab-group/tab-group.stories.ts
+++ b/packages/components/src/components/tab-group/tab-group.stories.ts
@@ -71,7 +71,7 @@ export const TabVariants = {
       <style>
         td.template {
           display: block !important;
-          width: 100%;
+          width: 500px;
         }
       </style>
       ${story()}
@@ -84,6 +84,7 @@ export const TabVariants = {
  */
 
 export const Scrollable = {
+  // parameters: { ...parameters, docs: { story: { inline: false, height: '550px' } } },
   render: (args: any) => {
     return html`
       ${generateTemplate({
@@ -92,25 +93,15 @@ export const Scrollable = {
             type: 'slot',
             name: 'default',
             values: [
-              { title: 'default', value: generateTabsAndPanels(1, 30) },
-              { title: 'container', value: generateTabsAndPanels(1, 30, 'container') }
+              { title: 'default', value: generateTabsAndPanels(1, 10) },
+              { title: 'container', value: generateTabsAndPanels(1, 10, 'container') }
             ]
           }
         },
         args
       })}
     `;
-  },
-  decorators: [
-    (story: () => typeof html) => html`
-      <style>
-        td.template {
-          width: 500px;
-        }
-      </style>
-      ${story()}
-    `
-  ]
+  }
 };
 
 export const Parts = {

--- a/packages/components/src/components/tab-group/tab-group.stories.ts
+++ b/packages/components/src/components/tab-group/tab-group.stories.ts
@@ -30,7 +30,6 @@ export default {
     value: generateTabsAndPanels(1, 5)
   }),
   argTypes
-  // parameters: { ...parameters, docs: { story: { inline: false, height: '250px' } } },
 };
 
 /**
@@ -47,8 +46,6 @@ export const Default = {
  * The sd-tab-group shows an alternative style when tabs are of the `container` variant.
  */
 export const TabVariants = {
-  // parameters: { ...parameters, docs: { story: { inline: false, height: '550px' } }, chromatic: { delay: 10000 } },
-
   render: (args: any) => {
     return html`
       ${generateTemplate({

--- a/packages/components/src/components/tab-group/tab-group.stories.ts
+++ b/packages/components/src/components/tab-group/tab-group.stories.ts
@@ -6,6 +6,7 @@ const { overrideArgs } = storybookHelpers('sd-tab-group');
 const { generateTemplate } = storybookTemplate('sd-tab-group');
 import { userEvent } from '@storybook/testing-library';
 import { waitUntil } from '@open-wc/testing-helpers';
+import { withActions } from '@storybook/addon-actions/decorator';
 
 function generateTabsAndPanels(
   startIndex: number,
@@ -29,7 +30,8 @@ export default {
     name: 'default',
     value: generateTabsAndPanels(1, 5)
   }),
-  argTypes
+  argTypes,
+  decorators: [withActions] as any
 };
 
 /**

--- a/packages/components/src/components/tab-group/tab-group.stories.ts
+++ b/packages/components/src/components/tab-group/tab-group.stories.ts
@@ -6,7 +6,6 @@ const { overrideArgs } = storybookHelpers('sd-tab-group');
 const { generateTemplate } = storybookTemplate('sd-tab-group');
 import { userEvent } from '@storybook/testing-library';
 import { waitUntil } from '@open-wc/testing-helpers';
-import { withActions } from '@storybook/addon-actions/decorator';
 
 function generateTabsAndPanels(
   startIndex: number,
@@ -30,9 +29,8 @@ export default {
     name: 'default',
     value: generateTabsAndPanels(1, 5)
   }),
-  argTypes,
-  parameters: { ...parameters, docs: { story: { inline: false, height: '250px' } } },
-  decorators: [withActions] as any
+  argTypes
+  // parameters: { ...parameters, docs: { story: { inline: false, height: '250px' } } },
 };
 
 /**
@@ -49,7 +47,7 @@ export const Default = {
  * The sd-tab-group shows an alternative style when tabs are of the `container` variant.
  */
 export const TabVariants = {
-  parameters: { ...parameters, docs: { story: { inline: false, height: '550px' } }, chromatic: { delay: 10000 } },
+  // parameters: { ...parameters, docs: { story: { inline: false, height: '550px' } }, chromatic: { delay: 10000 } },
 
   render: (args: any) => {
     return html`
@@ -68,7 +66,18 @@ export const TabVariants = {
         args
       })}
     `;
-  }
+  },
+  decorators: [
+    (story: () => typeof html) => html`
+      <style>
+        td.template {
+          display: block !important;
+          width: 100%;
+        }
+      </style>
+      ${story()}
+    `
+  ]
 };
 
 /**
@@ -76,8 +85,6 @@ export const TabVariants = {
  */
 
 export const Scrollable = {
-  parameters: { ...parameters, docs: { story: { inline: false, height: '550px' } } },
-
   render: (args: any) => {
     return html`
       ${generateTemplate({
@@ -86,8 +93,8 @@ export const Scrollable = {
             type: 'slot',
             name: 'default',
             values: [
-              { title: 'default', value: generateTabsAndPanels(1, 10) },
-              { title: 'container', value: generateTabsAndPanels(1, 10, 'container') }
+              { title: 'default', value: generateTabsAndPanels(1, 30) },
+              { title: 'container', value: generateTabsAndPanels(1, 30, 'container') }
             ]
           }
         },
@@ -99,8 +106,7 @@ export const Scrollable = {
     (story: () => typeof html) => html`
       <style>
         td.template {
-          display: block !important;
-          width: 50%;
+          width: 500px;
         }
       </style>
       ${story()}
@@ -112,8 +118,7 @@ export const Parts = {
   parameters: {
     controls: {
       exclude: ['base', 'nav', 'tabs', 'separation', 'body', 'scroll-button--start', 'scroll-button--end']
-    },
-    docs: { story: { inline: false, height: '2500px' } }
+    }
   },
   render: (args: any) => {
     return html`
@@ -141,6 +146,11 @@ export const Parts = {
                 <div style="width: 600px; position: relative;">%TEMPLATE%
                 </div>
               `
+            },
+            {
+              type: 'slot',
+              name: 'default',
+              value: generateTabsAndPanels(1, 30)
             }
           ],
           args
@@ -174,7 +184,15 @@ export const Mouseless = {
 };
 
 /**
- * As an option, users can justify the `sd-tab-group` to the center. To do this, set the `justify-content` property of the `tabs` part to `center`.
+ * As an option, users can justify the `sd-tab-group` to the center. To implement this sample, adjust the `tabs` CSS part as follows:
+ * 
+ * ```css
+ * 
+ *   sd-tab-group::part(tabs) {
+          justify-content: center;
+        }
+
+  * ```
  */
 
 export const SampleCentered = {
@@ -220,10 +238,28 @@ export const SampleCentered = {
 };
 
 /**
- * As an option, users can remove the line separating the tablist and the `sd-panel`.
+ * As an option, users can remove the line separating the tablist and the `sd-panel`. To implement this sample, apply the following adjustments to the `separation`, `base`, `scroll-button--start` and `scroll-button--end` CSS parts:
+ * 
+ * ```css
+ * 
+ * sd-tab-group::part(separation) {
+          display: none;
+        }
+
+        sd-tab::part(base):hover {
+          border-bottom: none !important;
+        }
+
+        sd-tab-group::part(scroll-button--start),
+        sd-tab-group::part(scroll-button--end) {
+          border-bottom: none;
+        }
+
+  * ```
  */
 
 export const SampleNoLine = {
+  parameters: { ...parameters, docs: { story: { inline: false, height: '250px' } } },
   name: 'Sample: No Line',
   render: () => {
     return html`
@@ -254,7 +290,13 @@ export const SampleNoLine = {
 };
 
 /**
- * Text can be bolded according to the users needs.
+ * Text can be bolded according to the users needs. To implement this sample, adjust the `base` CSS part as follows:
+ *   
+ * ```css
+        sd-tab::part(base) {
+          font-weight: bold;
+        }
+ * ```
  */
 
 export const SampleBold = {

--- a/packages/components/src/components/tab-group/tab-group.ts
+++ b/packages/components/src/components/tab-group/tab-group.ts
@@ -33,10 +33,8 @@ import type SdTabPanel from '../tab-panel/tab-panel';
  * @csspart scroll-button--start - The starting scroll button.
  * @csspart scroll-button--end - The ending scroll button.
  * @csspart scroll-button__base - The scroll button's exported `base` part.
- *
- * @cssproperty --track-color - The color of the indicator's track (the line that separates tabs from panels).
- * @cssproperty --track-width - The width of the indicator's track (the line that separates tabs from panels).
- */
+ * 
+ * */
 @customElement('sd-tab-group')
 export default class SdTabGroup extends SolidElement {
   private readonly localize = new LocalizeController(this);


### PR DESCRIPTION
## Description:
Closes [#866](https://github.com/solid-design-system/solid/issues/865) and [#865](https://github.com/solid-design-system/solid/issues/865). Some general optimisations of the docs included (removing unnecessary iframes).

## Definition of Reviewable:
*PR notes: Irrelevant elements should be removed.*
- [x] Documentation is created/updated
- [x] Stories (features, a11y) are created/updated
- [x] relevant tickets are linked
