### PR TITLE
fix: 🤔 logo for the Sample B Story of the sd-header

### DIFF
--- a/packages/components/src/components/header/header.stories.ts
+++ b/packages/components/src/components/header/header.stories.ts
@@ -269,7 +269,7 @@ export const SampleB = {
             value: `<div class="flex justify-between items-center">
             <!-- top-left-area start !-->
             <a class="flex flex-shrink" href='#'>
-              <img class='sm:h-12 lg:h-[56px] hidden sm:flex' src='/images/logo-unioninvestment-lg.svg' alt='Logo'/>
+              <img class='sm:h-12 lg:h-[56px] hidden sm:flex' src='images/logo-unioninvestment-lg.svg' alt='Logo'/>
               <img class='h-8 sm:hidden' src='images/logo-unioninvestment-sm.svg' alt='Logo'/>
             </a>
             <!-- top-left-area end !-->


### PR DESCRIPTION
## Description:
Fix a broken path for the logo in Sample B Story of the sd-header.

Closes #807 

