### PR TITLE
docs: add more ui-components to discontinued list

### DIFF
--- a/packages/components/src/docs/Migration/Intro.mdx
+++ b/packages/components/src/docs/Migration/Intro.mdx
@@ -34,7 +34,10 @@ Teams that have been using the following components should be aware that they wi
 
 - ui-contact
 - ui-link-list
+- ui-iframe
+- ui-portal
 - ui-superteaser
+- ui-text-image
 - ui-tag-group
 
 ### Most likely discontinued ui-components 🚫 ⁇ 🚫
@@ -43,7 +46,6 @@ Teams that have been using the following components should be aware that they wi
 
 > Note: This list is **highly non-binding** since we have not yet begun discussions about these components. If you are considering migrating any of them in the near future, please reach out to the SDS team for further evaluation.
 
-- ui-portal
 - ui-qr-code
 - ui-social-follow-links
 - ui-social-share-buttons


### PR DESCRIPTION
## Description:
Adding `ui-iframe`, `ui-portal` & `ui-text-image` to discontinued list in migration guides.

closes #891, #892 & #903

## Definition of Reviewable:
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
