### PR TITLE
ci(token): Deprecating shadow-md token

### DIFF
--- a/packages/tokens/src/tokens.json
+++ b/packages/tokens/src/tokens.json
@@ -1704,18 +1704,6 @@
       },
       "type": "boxShadow",
       "description": "Default shadow"
-    },
-    "shadow-md": {
-      "value": {
-        "x": "0",
-        "y": "3",
-        "blur": "1",
-        "spread": "0",
-        "color": "rgba({grey.800},{opacity-30})",
-        "type": "dropShadow"
-      },
-      "type": "boxShadow",
-      "description": "Used for map-markers"
     }
   },
   "$themes": [
@@ -2073,7 +2061,6 @@
         "border.error-400": "S:7980386a0e6e27f55854d0587d144b120f8fa4b7,",
         "background.error-400": "S:5d5b122cea8619e1d8a113201eba2440868e4534,",
         "shadow": "S:85ebfda49814ffc5013d9d51fe3a280497009551,",
-        "shadow-md": "S:20066b42f65fa0535ee3f5bf4b5b2738499b9939,",
         "background.accent-550": "S:b8ccfb22b4732f983ffe26852a58229f65a30dc9,",
         "icon-fill.accent-550": "S:8b5ab35d255587774d0637ec6aa31c057398fac2,",
         "border.accent-550": "S:d6282d319ac55e50f8228b43936d3215c5bd80c3,",


### PR DESCRIPTION
## Description:
following [#573](https://github.com/solid-design-system/solid/issues/573)
shadow-md was created from the style importing from the old sketch file. 
Since in the new design, it's visually sufficient for the map marker to consume the shadow token, this token should be deprecated to keep the token set consolidated. 

## Definition of Reviewable:
*PR notes: Irrelevant elements should be removed.*
- [x] Documentation is created/updated
- [x] Migration Guide is created/updated
- [x] relevant tickets are linked