### PR TITLE
ci(token): sd-expandable deprecating old gradient tokens

### DIFF
--- a/packages/tokens/src/tokens.json
+++ b/packages/tokens/src/tokens.json
@@ -1642,11 +1642,6 @@
         "type": "color",
         "description": "Used in sd-table (shadow)"
       },
-      "vertical-transparent-primary": {
-        "value": "linear-gradient(180deg, rgba({blue.default}, 0) 0%, rgba({blue.default}, 1) 80%, rgba({blue.default}, 1) 100%)",
-        "type": "color",
-        "description": "Used in sd-expandable"
-      },
       "vertical-transparent-black|40": {
         "value": "linear-gradient(180deg, rgba({black}, 0) 50%, rgba({black}, 0.4) 100%)",
         "type": "color",
@@ -1995,7 +1990,6 @@
         "background.transparent.primary-100|90": "S:b20812b59b164174da97db13ca61ad6432153bb5,",
         "background.transparent.white|80": "S:d129ecc47b93fe233efab250b3d714fb8246ab72,",
         "background.transparent.white|90": "S:73b805dfc0eb6adde50ab61895c200d622ee9ad2,",
-        "gradient.vertical-transparent-primary": "S:f9b8351a69146a1b56c484b6fb50e685bb8c1850,",
         "background.transparent.neutral-100|80": "S:72e0c2d239612a7303dcb6d9f4701d30ee8cd8ca,",
         "background.transparent.neutral-100|90": "S:4f252362ec4e912b31f17d1b413c3ece08648a6c,",
         "background.transparent.neutral-800|90": "S:ed86daba87d3fb153b61ebfee3c18e5bbdb72cfa,",

--- a/packages/tokens/src/tokens.json
+++ b/packages/tokens/src/tokens.json
@@ -1706,6 +1706,7 @@
         "value": "linear-gradient(180deg, rgba({white}, 0) 0%, rgba({white}, 1) 80%, rgba({white}, 1) 100%)",
         "type": "color",
         "description": "Used in sd-expandable (V.0.0.1 inverted) and sd-scrollable (V.0.0.2) -> Deprecate when V.1.0.0 is released"
+      },
       "horizontal-transparent-white": {
         "value": "linear-gradient(90deg, rgba({white}, 0) 0%, rgba({white}, 1) 80%, rgba({white}, 1) 100%)",
         "type": "color",

--- a/packages/tokens/src/tokens.json
+++ b/packages/tokens/src/tokens.json
@@ -1676,6 +1676,16 @@
         "value": "linear-gradient(90deg, rgba({black}, 0) 50%, rgba({black}, 0.4) 100%)",
         "type": "color",
         "description": "Used in sd-scrollable"
+      },
+      "vertical-transparent-primary": {
+        "value": "linear-gradient(180deg, rgba({blue.default}, 0) 0%, rgba({blue.default}, 1) 80%, rgba({blue.default}, 1) 100%)",
+        "type": "color",
+        "description": "Used in sd-expandable (V.0.0.1 inverted) -> Deprecate when V.1.0.0 is released"
+      },
+      "vertical-transparent-white": {
+        "value": "linear-gradient(180deg, rgba({white}, 0) 0%, rgba({white}, 1) 80%, rgba({white}, 1) 100%)",
+        "type": "color",
+        "description": "Used in sd-expandable (V.0.0.1 inverted) -> Deprecate when V.1.0.0 is released"
       }
     },
     "shadow": {

--- a/packages/tokens/src/tokens.json
+++ b/packages/tokens/src/tokens.json
@@ -1672,16 +1672,6 @@
         "type": "color",
         "description": "Used in sd-media-teaser"
       },
-      "horizontal-transparent-white": {
-        "value": "linear-gradient(90deg, rgba({white}, 0) 0%, rgba({white}, 1) 80%, rgba({white}, 1) 100%)",
-        "type": "color",
-        "description": "Used in sd-expandable, sd-scrollable"
-      },
-      "horizontal-white-transparent": {
-        "value": "linear-gradient(270deg, rgba({white}, 0) 0%, rgba({white}, 1) 80%, rgba({white}, 1) 100%)",
-        "type": "color",
-        "description": "Used in sd-expandable"
-      },
       "horizontal-transparent-black|40": {
         "value": "linear-gradient(270deg, rgba({black}, 0) 50%, rgba({black}, 0.4) 100%)",
         "type": "color",
@@ -2052,8 +2042,6 @@
         "*background-transparent.neutral-100|80": "S:8f2adbf13666832b7cfcfba61bc3001148341049,",
         "*background-transparent.neutral-100|90": "S:7bd47fd8899a59fa8ab07adf1cdc6d8ea4867e1a,",
         "gradient.vertical-white-transparent": "S:a696f6baa5da173917c2978b45c6a7bdffa11596,",
-        "gradient.horizontal-transparent-white": "S:409fed1c72dd7f7c69bacfd05ae279d9d6fac8cf,",
-        "gradient.horizontal-white-transparent": "S:b5191cb8ca6334405fe1cf7b85781302ace583c9,",
         "gradient.vertical-transparent-black|40": "S:de361ff08a83a4fa3178031b3ce96d1eba81095b,",
         "gradient.horizontal-transparent-black|40": "S:97a7984275e134fe104ed7a71ad5b446485fa7b2,",
         "gradient.horizontal-black|40-transparent": "S:dc3cef002229b153453e17bfaa083c89f7adde3a,",


### PR DESCRIPTION
## Description:
following #300 & [#168](https://github.com/solid-design-system/figma/issues/168)
since expandable's gradient is reworked into with masking. These tokens are no longer valid and need to be deprecated at releasing: 
-gradient.horizontal-white-transparent
-gradient.horizontal-transparent-white
-gradient.vertical-transparent-white
-gradient.vertical-transparent-primary

this token needs to be released:
-gradient.vertical-white-transparent

## Definition of Reviewable:
*PR notes: Irrelevant elements should be removed.*
- [ ] Documentation is created/updated
- [ ] Release note is added
- [ ] Migration Guide is created/updated
- [x] relevant tickets are linked