### PR TITLE
ci(token): sd-scrollable update gradients

### DIFF
--- a/packages/tokens/src/tokens.json
+++ b/packages/tokens/src/tokens.json
@@ -1615,7 +1615,7 @@
       "vertical-white-transparent": {
         "value": "linear-gradient(0deg, rgba({white}, 0) 5%, rgba({white}, 1) 20%, rgba({white}, 1) 100%)",
         "type": "color",
-        "description": "Used in sd-expandable (V.1.0.0)"
+        "description": "Used in sd-expandable, sd-scrollable (V.0.0.2)\n"
       },
       "vertical-black|40-transparent": {
         "value": "linear-gradient(0deg, rgba({black}, 0) 50%, rgba({black}, 0.4) 100%)",
@@ -1642,6 +1642,11 @@
         "type": "color",
         "description": "Used in sd-table (shadow)"
       },
+      "vertical-transparent-primary": {
+        "value": "linear-gradient(180deg, rgba({blue.default}, 0) 0%, rgba({blue.default}, 1) 80%, rgba({blue.default}, 1) 100%)",
+        "type": "color",
+        "description": "Used in sd-expandable"
+      },
       "vertical-transparent-black|40": {
         "value": "linear-gradient(180deg, rgba({black}, 0) 50%, rgba({black}, 0.4) 100%)",
         "type": "color",
@@ -1667,6 +1672,26 @@
         "type": "color",
         "description": "Used in sd-media-teaser"
       },
+      "horizontal-white-white|80-transparent": {
+        "value": "linear-gradient(270deg, rgba({white}, 0) 0%, rgba({white}, 0.05) 65%, rgba({white}, 1) 100%)",
+        "type": "color",
+        "description": "Used in sd-scrollable (masking for left button)"
+      },
+      "horizontal-transparent-white|80-white": {
+        "value": "linear-gradient(90deg, rgba({white}, 0) 15%, rgba({white}, 0.05) 75%, rgba({white}, 1) 100%)",
+        "type": "color",
+        "description": "Used in sd-scrollable (masking for right button)"
+      },
+      "vertical-transparent-white|80-white": {
+        "value": "linear-gradient(180deg, rgba({white}, 0) 5%, rgba({white}, 0.05) 75%, rgba({white}, 1) 100%)",
+        "type": "color",
+        "description": "Used in sd-scrollable (masking for top button)"
+      },
+      "vertical-white-white|80-transparent": {
+        "value": "linear-gradient(0deg, rgba({white}, 0) 5%, rgba({white}, 0.05) 75%, rgba({white}, 1) 100%)",
+        "type": "color",
+        "description": "Used in sd-scrollable (masking for bottom button)"
+      },
       "horizontal-transparent-black|40": {
         "value": "linear-gradient(270deg, rgba({black}, 0) 50%, rgba({black}, 0.4) 100%)",
         "type": "color",
@@ -1677,15 +1702,20 @@
         "type": "color",
         "description": "Used in sd-scrollable"
       },
-      "vertical-transparent-primary": {
-        "value": "linear-gradient(180deg, rgba({blue.default}, 0) 0%, rgba({blue.default}, 1) 80%, rgba({blue.default}, 1) 100%)",
-        "type": "color",
-        "description": "Used in sd-expandable (V.0.0.1) -> Deprecate when V.1.0.0 is released"
-      },
       "vertical-transparent-white": {
         "value": "linear-gradient(180deg, rgba({white}, 0) 0%, rgba({white}, 1) 80%, rgba({white}, 1) 100%)",
         "type": "color",
-        "description": "Used in sd-expandable (V.0.0.1) -> Deprecate when V.1.0.0 is released\n"
+        "description": "Used in sd-scrollable (V.0.0.2) -> Deprecate when V.1.0.0 is released"
+      },
+      "horizontal-transparent-white": {
+        "value": "linear-gradient(90deg, rgba({white}, 0) 0%, rgba({white}, 1) 80%, rgba({white}, 1) 100%)",
+        "type": "color",
+        "description": "Used in sd-scrollable (V.0.0.2) -> Deprecate when V.1.0.0 is released"
+      },
+      "horizontal-white-transparent": {
+        "value": "linear-gradient(270deg, rgba({white}, 0) 0%, rgba({white}, 1) 80%, rgba({white}, 1) 100%)",
+        "type": "color",
+        "description": "Used in sd-scrollable (V.0.0.2) -> Deprecate when V.1.0.0 is released"
       }
     },
     "shadow": {
@@ -2000,6 +2030,7 @@
         "background.transparent.primary-100|90": "S:b20812b59b164174da97db13ca61ad6432153bb5,",
         "background.transparent.white|80": "S:d129ecc47b93fe233efab250b3d714fb8246ab72,",
         "background.transparent.white|90": "S:73b805dfc0eb6adde50ab61895c200d622ee9ad2,",
+        "gradient.vertical-transparent-primary": "S:f9b8351a69146a1b56c484b6fb50e685bb8c1850,",
         "background.transparent.neutral-100|80": "S:72e0c2d239612a7303dcb6d9f4701d30ee8cd8ca,",
         "background.transparent.neutral-100|90": "S:4f252362ec4e912b31f17d1b413c3ece08648a6c,",
         "background.transparent.neutral-800|90": "S:ed86daba87d3fb153b61ebfee3c18e5bbdb72cfa,",
@@ -2079,7 +2110,8 @@
         "gradient.horizontal-black|10-transparent": "S:45ad69867f4b97c2022ad39a7c35eb7e30fabdfe,",
         "*background-transparent.primary-800|90": "S:e23a0748a9917f54cd3a6623af0e68ebfbff7e4a,",
         "gradient.vertical-transparent-primary-800|75": "S:6640acb070ae7bee8371d25ef1559ada8bca07f2,",
-        "gradient.vertical-primary-800|75-transparent": "S:e36bacb650701df661f8ee2a8053ffb65ca167f3,"
+        "gradient.vertical-primary-800|75-transparent": "S:e36bacb650701df661f8ee2a8053ffb65ca167f3,",
+        "gradient.horizontal-white-white|80-transparent": "S:b5191cb8ca6334405fe1cf7b85781302ace583c9,"
       }
     }
   ],


### PR DESCRIPTION
## Description:
following #289  & [#167](https://github.com/solid-design-system/figma/issues/167)
since expandable's gradient is reworked into with masking. These tokens are no longer valid and need to be released
- gradient.horizontal-white-white|80-transparent
- gradient.horizontal-transparent-white|80-white
- gradient.vertical-white-white|80-transparent
- gradient.vertical-transparent-white|80-white

these tokens need to be deprecated
- gradient.vertical-white-transparent
- gradient.horizontal-transparent-white
- gradient.horizontal-white-transparent

## Definition of Reviewable:
*PR notes: Irrelevant elements should be removed.*
- [ ] Documentation is created/updated
- [ ] Release note is added
- [ ] Migration Guide is created/updated
- [x] relevant tickets are linked