### PR TITLE
fix: exclude event names from versioning

### DIFF
--- a/packages/components/scripts/node-version-components.cjs
+++ b/packages/components/scripts/node-version-components.cjs
@@ -62,7 +62,8 @@ function versionComponents(source, destination) {
         let fileContent = fs.readFileSync(filePath, 'utf-8');
 
         components.forEach(componentName => {
-          const regex = new RegExp(`(?!--)sd-${componentName}`, 'g');
+          // Events and CSS Variables should not be versioned
+          const regex = new RegExp(`(?<!this.emit\\(")(?!--)sd-${componentName}`, 'g');
           fileContent = fileContent.replace(regex, `sd-${currentVersion}-${componentName}`);
         });
 


### PR DESCRIPTION
## Description:
This excludes event names from versioning. 

Before that the event `sd-input` was renamed to `sd-2-11-0-input`. This came from the fact, that the event had the same name as a component. This change omits this. 

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [x] Documentation is created/updated
