### PR TITLE
ci(token): add *background-transparent|30 token for sd-map-marker

### DIFF
--- a/packages/tokens/src/tokens.json
+++ b/packages/tokens/src/tokens.json
@@ -1184,6 +1184,11 @@
       }
     },
     "*background-transparent": {
+      "primary|30": {
+        "value": "rgba({blue.default}, 0.3)",
+        "type": "color",
+        "description": "Used for sd-map-marker"
+      },
       "primary|80": {
         "value": "rgba({blue.default}, 0.8)",
         "type": "color",


### PR DESCRIPTION
## Description:
link to ticket #963 
following [#573](https://github.com/solid-design-system/solid/issues/573)
closes #573 
shadow-md was created from the style importing from the old sketch file. 
Since in the new design, it's visually sufficient for the map marker to consume the shadow token, this token is no longer valid and need to be deprecated at releasing

## Definition of Reviewable:
*PR notes: Irrelevant elements should be removed.*
- [x] Documentation is created/updated
- [x] Migration Guide is created/updated
- [x] relevant tickets are linked
