### PR TITLE
fix: accept full height of container

### DIFF
--- a/packages/components/src/components/textarea/textarea.ts
+++ b/packages/components/src/components/textarea/textarea.ts
@@ -333,7 +333,7 @@ export default class SdTextarea extends SolidElement implements SolidFormControl
     }[this.size];
 
     return html`
-      <div part="form-control" class="text-left">
+      <div part="form-control" class="flex flex-col w-full text-left">
         <label
           part="form-control-label"
           id="label"
@@ -344,7 +344,7 @@ export default class SdTextarea extends SolidElement implements SolidFormControl
           <slot name="label">${this.label}</slot>
         </label>
 
-        <div part="form-control-input" class=${cx('relative w-full', this.disabled && 'cursor-not-allowed')}>
+        <div part="form-control-input" class=${cx('relative w-full h-full', this.disabled && 'cursor-not-allowed')}>
           <div
             part="border"
             class=${cx(
@@ -364,7 +364,7 @@ export default class SdTextarea extends SolidElement implements SolidFormControl
           <div
             part="base"
             class=${cx(
-              'textarea px-4 flex items-top rounded-default bg-white group',
+              'textarea px-4 h-full flex items-top rounded-default bg-white group',
               {
                 sm: 'textarea-sm py-1',
                 md: 'textarea-md py-1',


### PR DESCRIPTION
## Description:
Changed the logic regarding #719 to accept full height inside a container 

## Definition of Reviewable:
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
