### PR TITLE
feat: ✨ optimize `autocomplete-config` to allow max-height for listbox

### DIFF
--- a/packages/components/src/patterns/autocomplete/autocomplete.stories.ts
+++ b/packages/components/src/patterns/autocomplete/autocomplete.stories.ts
@@ -433,6 +433,10 @@ export const GroupElements = {
   }
 };
 
+/**
+ * This example demonstrates how to customize the appearance of the autocomplete suggestions popup by setting a custom `max-height`.
+ * There are two parts promoted (`autocomplete-list`, `autocomplete-popup`) and you can use the first one to set the max-height.
+ */
 export const SuggestionContainerHeight = {
   parameters: {
     controls: {
@@ -443,7 +447,12 @@ export const SuggestionContainerHeight = {
     const setupAutocomplete = solidAutocomplete;
     const data = mock;
     return html`
-      <sd-input id="show-all-on-click-example" type="search"><b slot="label">Show all items on click</b></sd-input>
+      <sd-input id="show-all-on-click-example" type="search"><b slot="label">Max-height for list</b></sd-input>
+      <style>
+        sd-input#show-all-on-click-example::part(autocomplete-list) {
+          max-height: 110px;
+        }
+      </style>
       <script type="module">
         import './autocomplete/autoComplete.min.js';
 

--- a/packages/components/src/patterns/autocomplete/autocomplete.stories.ts
+++ b/packages/components/src/patterns/autocomplete/autocomplete.stories.ts
@@ -447,9 +447,9 @@ export const SuggestionContainerHeight = {
     const setupAutocomplete = solidAutocomplete;
     const data = mock;
     return html`
-      <sd-input id="show-all-on-click-example" type="search"><b slot="label">Max-height for list</b></sd-input>
+      <sd-input id="container-height" type="search"><b slot="label">Max-height for list</b></sd-input>
       <style>
-        sd-input#show-all-on-click-example::part(autocomplete-list) {
+        sd-input#container-height::part(listbox) {
           max-height: 110px;
         }
       </style>
@@ -463,7 +463,7 @@ export const SuggestionContainerHeight = {
 
         Promise.all([customElements.whenDefined('sd-input'), customElements.whenDefined('sd-popup')]).then(() => {
           /** Show all on click */
-          const { config: showAllOnClickConfig } = setupAutocomplete('#show-all-on-click-example');
+          const { config: showAllOnClickConfig } = setupAutocomplete('#container-height');
           const showAllOnClickExample = new autoComplete({
             ...showAllOnClickConfig,
             threshold: 0,

--- a/packages/components/src/patterns/autocomplete/autocomplete.stories.ts
+++ b/packages/components/src/patterns/autocomplete/autocomplete.stories.ts
@@ -435,7 +435,7 @@ export const GroupElements = {
 
 /**
  * This example demonstrates how to customize the appearance of the autocomplete suggestions popup by setting a custom `max-height`.
- * There are two parts promoted (`autocomplete-list`, `autocomplete-popup`) and you can use the first one to set the max-height.
+ * There are two additional parts added (`listbox`, `popup`) and you can use the first one to set the `max-height`.
  */
 export const SuggestionContainerHeight = {
   parameters: {

--- a/packages/components/src/utilities/autocomplete-config.test.ts
+++ b/packages/components/src/utilities/autocomplete-config.test.ts
@@ -98,7 +98,6 @@ describe('sd-input', () => {
         <sd-input id="autocomplete" type="search"></sd-input>
       `);
 
-      // Promise.all([customElements.whenDefined('sd-input'), customElements.whenDefined('sd-popup')]).then(() => {
       // Tests run differently when served as ESM vs. bundled
       // Here we are checking for the existence of the Solid Components global
       // to determine which mode we are in.
@@ -118,7 +117,7 @@ describe('sd-input', () => {
         mock
       });
 
-      expect(autoCompleteJS.resultsList.tag).to.equal('sd-popup');
+      expect(autoCompleteJS.resultsList.tag).to.equal('ul');
       expect(autoCompleteJS.resultsList.maxResults).to.equal(5);
       expect(autoCompleteJS.resultItem.tag).to.equal('li');
       /* eslint-enable */

--- a/packages/components/src/utilities/autocomplete-config.ts
+++ b/packages/components/src/utilities/autocomplete-config.ts
@@ -26,11 +26,11 @@ export function setupAutocomplete(
   /** Setup elements and styles for autocomplete.js */
   input.addEventListener('init', () => {
     const ul = sdInput.shadowRoot?.querySelector('ul');
-    ul?.setAttribute('part', 'autocomplete-list');
+    ul?.setAttribute('part', 'listbox');
     const popup = document.createElement('sd-popup');
     popup.appendChild(ul!);
     sdInput.shadowRoot?.appendChild(popup);
-    popup?.setAttribute('part', 'autocomplete-popup');
+    popup?.setAttribute('exportparts', 'popup__content');
     if (popup) {
       popup.active = false;
       popup.autoSize = 'vertical';

--- a/packages/components/src/utilities/autocomplete-config.ts
+++ b/packages/components/src/utilities/autocomplete-config.ts
@@ -25,9 +25,14 @@ export function setupAutocomplete(
 
   /** Setup elements and styles for autocomplete.js */
   input.addEventListener('init', () => {
-    const popup = sdInput.shadowRoot?.querySelector('sd-popup');
+    const ul = sdInput.shadowRoot?.querySelector('ul');
+    ul?.setAttribute('part', 'autocomplete-list');
+    const popup = document.createElement('sd-popup');
+    popup.appendChild(ul!);
+    sdInput.shadowRoot?.appendChild(popup);
+    popup?.setAttribute('part', 'autocomplete-popup');
     if (popup) {
-      popup.active = true;
+      popup.active = false;
       popup.autoSize = 'vertical';
       popup.autoSizePadding = 16;
       popup.placement = 'bottom-start';
@@ -75,11 +80,13 @@ export function setupAutocomplete(
 
   /** Open and close events to add styles to the input */
   input.addEventListener('open', () => {
+    sdInput.shadowRoot?.querySelector('sd-popup')?.setAttribute('active', 'true');
     sdInput.shadowRoot?.querySelector('[part="border"]')?.classList.add('rounded-b-none');
     sdInput.shadowRoot?.querySelector('[part="form-control"]')?.classList.add('z-50');
   });
 
   input.addEventListener('close', () => {
+    sdInput.shadowRoot?.querySelector('sd-popup')?.removeAttribute('active');
     sdInput.shadowRoot?.querySelector('[part="border"]')?.classList.remove('rounded-b-none');
     sdInput.shadowRoot?.querySelector('[part="form-control"]')?.classList.remove('z-50');
   });
@@ -104,7 +111,7 @@ export function setupAutocomplete(
         return input;
       },
       resultsList: {
-        tag: 'sd-popup'
+        tag: 'ul'
       },
       wrapper: false
     }


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
<!-- *PR notes: Please describe the changes in this PR.* -->

This optimizes the DOM structure created by the `autocomplete-config` to allow `max-height`. In addition this improves a11y as a `ul` is now used as wrapper.

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
