### PR TITLE
feat: accept svg string in icon libraries

### DIFF
--- a/packages/components/src/components/icon/icon.test.ts
+++ b/packages/components/src/components/icon/icon.test.ts
@@ -45,6 +45,16 @@ describe('<sd-icon>', () => {
       },
       mutator: (svg: SVGElement) => svg.setAttribute('fill', 'currentColor')
     });
+
+    registerIconLibraryForTest('test-string-library', {
+      resolver: (name: keyof typeof testLibraryIcons) => {
+        if (name in testLibraryIcons) {
+          return testLibraryIcons[name];
+        }
+        return '';
+      },
+      mutator: (svg: SVGElement) => svg.setAttribute('fill', 'currentColor')
+    });
   });
 
   describe('defaults ', () => {
@@ -107,6 +117,21 @@ describe('<sd-icon>', () => {
 
       expect(el.shadowRoot?.querySelector('svg')).to.exist;
       expect(el.shadowRoot?.querySelector('svg')?.getAttribute('id')).to.equal(fakeId);
+    });
+  });
+
+  describe('when a SVG string is provided', () => {
+    it('it is rendered', async () => {
+      const el = await fixture<SdIcon>(html`<sd-icon library="test-string-library"></sd-icon>`);
+      const listener = oneEvent(el, 'sd-load', false);
+
+      el.name = 'test-icon1';
+      await listener;
+      await elementUpdated(el);
+
+      const svg = el.shadowRoot?.querySelector('svg');
+      expect(svg).to.exist;
+      expect(svg?.id).to.equal('test-icon1');
     });
   });
 

--- a/packages/components/src/components/icon/library.system.ts
+++ b/packages/components/src/components/icon/library.system.ts
@@ -99,7 +99,7 @@ const systemLibrary: IconLibrary = {
   name: 'system',
   resolver: (name: keyof typeof icons) => {
     if (name in icons) {
-      return `data:image/svg+xml,${encodeURIComponent(icons[name])}`;
+      return icons[name];
     }
     return '';
   },

--- a/packages/components/src/components/tab-group/tab-group.test.ts
+++ b/packages/components/src/components/tab-group/tab-group.test.ts
@@ -17,7 +17,6 @@ interface CustomEventPayload {
 const waitForScrollButtonsToBeRendered = async (tabGroup: SdTabGroup): Promise<void> => {
   await waitUntil(() => {
     const scrollButtons = tabGroup.shadowRoot?.querySelectorAll('button');
-    console.log('scrollButtons ARE RENDERED', scrollButtons);
     return scrollButtons?.length === 2;
   });
 };


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
<!-- *PR notes: Please describe the changes in this PR.* -→

This PR adds the ability to accept SVG strings in icon libraries. While this doesn't make anything more safe, it enables to bypass CSP restrictions to close #995. Still, this should be more seen as a Proof of Concept, as I'm not sure, if we should enable this feature.

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
