### PR TITLE
ci: stop non-security renovate updates [skip chromatic] 

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -37,7 +37,7 @@ jobs:
     chromatic-deployment-pr:
         name: Verify Chromatic
         needs: [quality-gate]
-        if: ${{!contains(github.event.pull_request.title, '[skip chromatic]' && !startsWith(github.event.pull_request.title, 'chore(security deps): ')}}
+        if: ${{!contains(github.event.pull_request.title, '[skip chromatic]') && !startsWith(github.event.pull_request.title, 'chore(security deps):')}}
         runs-on: ubuntu-latest
         steps:
             # 👇 Version 2 of the action

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
-jobs: 
+jobs:
     quality-gate:
         name: Install, verify and build
         runs-on: ubuntu-latest
@@ -37,7 +37,7 @@ jobs:
     chromatic-deployment-pr:
         name: Verify Chromatic
         needs: [quality-gate]
-        if: ${{!contains(github.event.pull_request.title, '[skip chromatic]')}}
+        if: ${{!contains(github.event.pull_request.title, '[skip chromatic]' && !startsWith(github.event.pull_request.title, 'chore(security deps): ')}}
         runs-on: ubuntu-latest
         steps:
             # 👇 Version 2 of the action

--- a/DEVELOPER_STARTING_GUIDE.md
+++ b/DEVELOPER_STARTING_GUIDE.md
@@ -16,6 +16,7 @@
   - [Work Process](#work-process)
     - [Components](#components)
     - [Styles](#styles)
+    - [Security Updates](#security-updates)
   - [Repository Overview](#repository-overview)
   - [Technologies](#technologies)
   - [Figma Library](#figma-library)
@@ -131,6 +132,11 @@ If you are working on a style, follow the steps below:
 4. Import your styles into the `packages/components/src/solid-styles.css` file. This step is crucial for enabling other Solid components to access the new styles.
 
 _ You can always refer to the existing components and styles to familiarize yourself with the workflow!_
+
+### Security Updates
+
+In our security workflow, Renovate (GitHub App) automatically identifies and updates security issues in our project dependencies.
+Renovate also creates a “Dependency Dashboard” ticket to track all found updates. During each iteration, we plan and assign the dashboard ticket to a specific team member. The assigned team member has to update the described packages by runing `pnpm update all`, creating a corresponding PR, and finally closing the ticket. This process ensures efficient handling of security updates while maintaining clear accountability within the team.
 
 ## Repository Overview
 

--- a/renovate.json
+++ b/renovate.json
@@ -9,10 +9,12 @@
   "timezone": "Europe/Berlin",
   "rebaseWhen": "never",
   "vulnerabilityAlerts": {
+  "enabled": true,
     "labels": [
       "npm dependencies, renovate, security"
     ],
     "automerge": true
   },
+  "osvVulnerabilityAlerts": true,
   "commitMessagePrefix": "chore(security deps): "
 }

--- a/renovate.json
+++ b/renovate.json
@@ -7,28 +7,12 @@
   ],
   "schedule": "before 5am every weekday",
   "timezone": "Europe/Berlin",
-  "matchUpdateTypes": [
-    "security"
-  ],
-  "lockFileMaintenance": {
-    "enabled": true,
-    "automerge": true,
-    "automergeType": "pr",
-    "matchUpdateTypes": [
-      "security"
-    ]
-  },
-  "major": {
-    "automerge": false
-  },
-  "prConcurrentLimit": 10,
-  "automergeType": "pr",
-  "automergeStrategy": "squash",
-  "automergeSchedule": [
-    "after 10pm every weekday",
-    "before 5am every weekday"
-  ],
-  "autoApprove": true,
   "rebaseWhen": "never",
+  "vulnerabilityAlerts": {
+    "labels": [
+      "npm dependencies, renovate, security"
+    ],
+    "automerge": true
+  },
   "commitMessagePrefix": "chore(security deps): "
 }

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["schedule:daily", ":disableRateLimiting", "security:only-security-updates"],
   "timezone": "Europe/Berlin",
-  "rebaseWhen": "never"
+  "rebaseWhen": "never",
+  "commitMessagePrefix": "chore(security deps): "
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,29 +1,22 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", "schedule:daily", ":disableRateLimiting"],
+  "extends": [
+    "config:base",
+    "schedule:daily",
+    ":disableRateLimiting"
+  ],
   "schedule": "before 5am every weekday",
   "timezone": "Europe/Berlin",
-  "packageRules": [
-    {
-      "matchUpdateTypes": ["minor", "patch"],
-      "matchCurrentVersion": ">= 1.0.0",
-      "automerge": true
-    },
-    {
-      "matchDepNames": ["node", "pnpm"],
-      "enabled": false
-    },
-    {
-      "matchPackagePrefixes": ["@types/"],
-      "automerge": true,
-      "major": {
-        "automerge": false
-      }
-    }
+  "matchUpdateTypes": [
+    "security"
   ],
   "lockFileMaintenance": {
     "enabled": true,
-    "automerge": false
+    "automerge": true,
+    "automergeType": "pr",
+    "matchUpdateTypes": [
+      "security"
+    ]
   },
   "major": {
     "automerge": false
@@ -31,7 +24,11 @@
   "prConcurrentLimit": 10,
   "automergeType": "pr",
   "automergeStrategy": "squash",
-  "automergeSchedule": ["after 10pm every weekday", "before 5am every weekday"],
+  "automergeSchedule": [
+    "after 10pm every weekday",
+    "before 5am every weekday"
+  ],
   "autoApprove": true,
-  "rebaseWhen": "never"
+  "rebaseWhen": "never",
+  "commitMessagePrefix": "chore(security deps): "
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,20 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base",
-    "schedule:daily",
-    ":disableRateLimiting"
-  ],
-  "schedule": "before 5am every weekday",
+  "extends": ["schedule:daily", ":disableRateLimiting", "security:only-security-updates"],
   "timezone": "Europe/Berlin",
-  "rebaseWhen": "never",
-  "vulnerabilityAlerts": {
-  "enabled": true,
-    "labels": [
-      "npm dependencies, renovate, security"
-    ],
-    "automerge": true
-  },
-  "osvVulnerabilityAlerts": true,
-  "commitMessagePrefix": "chore(security deps): "
+  "rebaseWhen": "never"
 }


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
<!-- *PR notes: Please describe the changes in this PR.* -->
I added a preset to carry out only security updates. I also removed a lot of redundant config that was already covered by presets. Closes #914.  

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [x] relevant tickets are linked
