### PR TITLE
ci(token): deprecating old gradient tokens for sd-expandable & sd-scrollable

### DIFF
--- a/packages/tokens/src/tokens.json
+++ b/packages/tokens/src/tokens.json
@@ -1701,26 +1701,6 @@
         "value": "linear-gradient(90deg, rgba({black}, 0) 50%, rgba({black}, 0.4) 100%)",
         "type": "color",
         "description": "Used in sd-scrollable"
-      },
-      "vertical-transparent-primary": {
-        "value": "linear-gradient(180deg, rgba({blue.default}, 0) 0%, rgba({blue.default}, 1) 80%, rgba({blue.default}, 1) 100%)",
-        "type": "color",
-        "description": "Used in sd-expandable (V.0.0.1 inverted) -> Deprecate when V.1.0.0 is released"
-      },
-      "vertical-transparent-white": {
-        "value": "linear-gradient(180deg, rgba({white}, 0) 0%, rgba({white}, 1) 80%, rgba({white}, 1) 100%)",
-        "type": "color",
-        "description": "Used in sd-expandable (V.0.0.1 inverted) and sd-scrollable (V.0.0.2) -> Deprecate when V.1.0.0 is released"
-      },
-      "horizontal-transparent-white": {
-        "value": "linear-gradient(90deg, rgba({white}, 0) 0%, rgba({white}, 1) 80%, rgba({white}, 1) 100%)",
-        "type": "color",
-        "description": "Used in sd-scrollable (V.0.0.2) -> Deprecate when V.1.0.0 is released"
-      },
-      "horizontal-white-transparent": {
-        "value": "linear-gradient(270deg, rgba({white}, 0) 0%, rgba({white}, 1) 80%, rgba({white}, 1) 100%)",
-        "type": "color",
-        "description": "Used in sd-scrollable (V.0.0.2) -> Deprecate when V.1.0.0 is released"
       }
     },
     "shadow": {


### PR DESCRIPTION
## Description

following #300 & #289, old gradients used for sd-scrollable V.0.0.1 & sd-expandable V.0.0.1 must be deprecated:

-gradient.vertical-white-transparent
-gradient.horizontal-transparent-white
-gradient.horizontal-white-transparent
-gradient.vertical-transparent-white
-gradient.vertical-transparent-primary

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated

