### PR TITLE
docs: fix firefox bug in table cell example (close #911)

### DIFF
--- a/packages/components/src/styles/table-cell/table-cell.stories.ts
+++ b/packages/components/src/styles/table-cell/table-cell.stories.ts
@@ -545,7 +545,7 @@ export const AdvancedSamples = {
                 ${rowData.map((cellData, columIndex) => {
                   if (columIndex === 0) {
                     return html`<th
-                      class="sd-table-cell absolute left-0 top-auto sticky left-0 z-[2] sd-table-cell--shadow-right ${rowIndex %
+                      class="sd-table-cell top-auto sticky left-0 z-[2] bg-clip-padding sd-table-cell--shadow-right ${rowIndex %
                         2 ===
                       0
                         ? 'sd-table-cell--bg-white'
@@ -593,7 +593,7 @@ export const AdvancedSamples = {
                 ${rowData.map((cellData, columIndex) => {
                   if (columIndex === 4) {
                     return html`<th
-                      class="sd-table-cell absolute left-0 top-auto sticky right-0 z-[2] sd-table-cell--shadow-left sd-table-cell--shadow-active ${rowIndex %
+                      class="sd-table-cell left-0 top-auto sticky right-0 z-[2] sd-table-cell--shadow-left sd-table-cell--shadow-active ${rowIndex %
                         2 ===
                       0
                         ? 'sd-table-cell--bg-white'


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
<!-- *PR notes: Please describe the changes in this PR.* -->

This fixes a bug in FireFox 115.11.0esr that did hide borders when `position: sticky` is set on an element. This will be solved in a future ESR version and therefore is only implemented in the pattern and not in the `sd-table` itself. Furthermore some redundant TailwindCSS classes were removed.

![CleanShot 2024-06-06 at 11 44 33@2x](https://github.com/solid-design-system/solid/assets/26542182/de09ef3d-8985-4056-b685-8e600ae74748)

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [x] Documentation is created/updated
- [x] relevant tickets are linked
