### PR TITLE
fix: add utilities to exports

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -19,12 +19,20 @@
       "import": "./dist/package/components/*",
       "types": "./dist/package/solid-components.d.ts"
     },
+    "./unversioned-utilities/*": {
+      "import": "./dist/package/utilities/*",
+      "types": "./dist/package/solid-components.d.ts"
+    },
     "./versioned": {
       "types": "./dist/versioned-package/solid-components.d.ts",
       "import": "./dist/versioned-package/solid-components.js"
     },
     "./versioned/*": {
       "import": "./dist/versioned-package/components/*",
+      "types": "./dist/versioned-package/solid-components.d.ts"
+    },
+    "./versioned-utilities/*": {
+      "import": "./dist/versioned-package/utilities/*",
       "types": "./dist/versioned-package/solid-components.d.ts"
     },
     "./unversioned-styles": {

--- a/packages/components/scripts/node-optimize-chromatic.cjs
+++ b/packages/components/scripts/node-optimize-chromatic.cjs
@@ -11,8 +11,17 @@ fs.readdir(directoryPath, (err, files) => {
   }
 
   files.forEach(file => {
-    if (file.startsWith('solid-element-') && file.endsWith('.js')) {
-      matchedFiles.push(file);
+    if (
+      (file.startsWith('solid-element-') && file.endsWith('.js')) ||
+      (file.startsWith('solid-components-') && file.endsWith('.js'))
+    ) {
+      if (
+        fs
+          .readFileSync(path.join(directoryPath, file), 'utf8')
+          .includes('.animate-spin{animation:spin 1s linear infinite}') === true
+      ) {
+        matchedFiles.push(file);
+      }
     }
   });
 
@@ -45,7 +54,6 @@ fs.readdir(directoryPath, (err, files) => {
         });
       } else {
         console.error('File does not contain the required string.');
-        process.exit(1);
       }
     });
   } else if (matchedFiles.length > 1) {

--- a/packages/components/src/patterns/autocomplete/autocomplete.stories.ts
+++ b/packages/components/src/patterns/autocomplete/autocomplete.stories.ts
@@ -29,7 +29,7 @@ import { setupAutocomplete as solidAutocomplete } from '../../solid-components';
  * <script type="module">
  *   import '@tarekraafat/autocomplete.js';
  *
- *   import { setupAutocomplete } from '@solid-design-system/unversioned';
+ *   import { setupAutocomplete } from '@solid-design-system/unversioned-utilities/autocomplete-config';
  *
  *   Promise.all([customElements.whenDefined('sd-input'), customElements.whenDefined('sd-popup')]).then(() => {
  *     const { config: simpleConfig } = setupAutocomplete('#simple-example');

--- a/packages/components/src/utilities/autocomplete-config.ts
+++ b/packages/components/src/utilities/autocomplete-config.ts
@@ -1,3 +1,5 @@
+import '../components/popup/popup';
+
 /**
  * This function is a helper to quickly setup autocomplete.js for Solid components.
  * Besides some needed defaults it adds additional styles and event listeners.


### PR DESCRIPTION
Enables to import utilities. This solves to easily import e. g. `autocomplete-config` without having to point to the direct path via `node_modules/@solid-design-system/...`.

Everything was tested locally:

![CleanShot 2024-06-18 at 11 05 25@2x](https://github.com/solid-design-system/solid/assets/26542182/52230929-4b2a-42f3-bcbb-0dc046451b85)


## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
