### PR TITLE
fix: add missing tailwind classes

### DIFF
--- a/packages/components/tailwind.config.cjs
+++ b/packages/components/tailwind.config.cjs
@@ -35,7 +35,12 @@ const includeStorybookStories = process.env.npm_lifecycle_event?.includes('story
 module.exports = {
   content: includeStorybookStories
     ? ['./src/**/*.ts', './src/**/*.mdx']
-    : ['./src/components/**/*.ts', '!./src/components/**/*.stories.ts', '!./src/components/**/*.test.ts'],
+    : [
+        './src/components/**/*.ts',
+        '!./src/components/**/*.stories.ts',
+        '!./src/components/**/*.test.ts',
+        './src/utilities/autocomplete-config.ts'
+      ],
   theme,
   plugins: [
     require('@mariohamann/tailwindcss-var'),


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
<!-- *PR notes: Please describe the changes in this PR.* -->

Current bug:
![image](https://github.com/solid-design-system/solid/assets/26542182/59fb6ea5-6340-4509-9cdc-bd5bd674a7bc)
This was not apparent in Storybook, as for Storybook we provide more CSS at all.


Fix shows that class is now part of published CSS:
![CleanShot 2024-06-27 at 11 46 22@2x](https://github.com/solid-design-system/solid/assets/26542182/7b7c848a-66cc-469f-b714-3f0ebd148757)

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
