### PR TITLE
ci(token): add 4 gradients for sd-flipcard [skip chromatic]

### DIFF
--- a/packages/tokens/src/tokens.json
+++ b/packages/tokens/src/tokens.json
@@ -1670,22 +1670,42 @@
       "vertical-transparent-white|60": {
         "value": "linear-gradient(180deg, rgba({white}, 0) 0%, rgba({white}, 0.6) 100%)",
         "type": "color",
-        "description": "Used in sd-teaser-media (gradient light, top gradient layer)"
+        "description": "Used in sd-teaser-media (gradient light), sd-flipcard (gradient light bottom)"
       },
       "vertical-white|60-white|75": {
         "value": "linear-gradient(180deg, rgba({white}, 0.6) 0%, rgba({white}, 0.75) 100%)",
         "type": "color",
-        "description": "Used in sd-teaser-media (gradient light, bottom gradient layer)"
+        "description": "Used in sd-teaser-media (gradient light), sd-flipcard (gradient light bottom)"
       },
       "vertical-transparent-primary-800|60": {
         "value": "linear-gradient(180deg, rgba( {blue.800}, 0) 0%, rgba( {blue.800}, 0.6) 100%)",
         "type": "color",
-        "description": "Used in sd-media-teaser"
+        "description": "Used in sd-media-teaser, sd-flipcard (gradient dark bottom)"
       },
       "vertical-primary-800|60-primary-800|75": {
         "value": "linear-gradient(180deg, rgba( {blue.800}, 0.6) 0%, rgba( {blue.800}, 0.75) 100%)",
         "type": "color",
-        "description": "Used in sd-media-teaser"
+        "description": "Used in sd-media-teaser, sd-flipcard (gradient dark bottom)"
+      },
+      "vertical-primary-800|75-primary-800|60": {
+        "value": "linear-gradient(180deg, rgba( {blue.800}, 0.75) 0%, rgba( {blue.800}, 0.6) 100%)",
+        "type": "color",
+        "description": "Used in sd-flipcard (gradient dark top)"
+      },
+      "vertical-primary-800|60-transparent": {
+        "value": "linear-gradient(180deg, rgba( {blue.800}, 0.6) 0%, rgba( {blue.800}, 0) 100%)",
+        "type": "color",
+        "description": "Used in sd-flipcard (gradient dark top)"
+      },
+      "vertical-white|75-white|60": {
+        "value": "linear-gradient(180deg, rgba( {white}, 0.75) 0%, rgba( {white}, 0.6) 100%)",
+        "type": "color",
+        "description": "Used in sd-flipcard (gradient light top)"
+      },
+      "vertical-white|60-transparent": {
+        "value": "linear-gradient(180deg, rgba( {white}, 0.6) 0%, rgba( {white}, 0) 100%)",
+        "type": "color",
+        "description": "Used in sd-flipcard (gradient light top)"
       },
       "horizontal-white-white|80-transparent": {
         "value": "linear-gradient(270deg, rgba({white}, 0) 0%, rgba({white}, 0.05) 65%, rgba({white}, 1) 100%)",


### PR DESCRIPTION
following #1013 
4 color tokens need to be added for sd-flipcard:
gradient.vertical-white|75-white|60 
gradient.vertical-white|60-transparent
gradient.vertical-primary-800|75-primary-800|60
gradient.vertical-primary-800|60-transparent

<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
<!-- *PR notes: Please describe the changes in this PR.* -->

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [x] Documentation is created/updated
- [x] relevant tickets are linked
