### PR TITLE
feat: 🎸 adding min and max posibility for date type of input

### DIFF
--- a/packages/components/src/components/input/input.stories.ts
+++ b/packages/components/src/components/input/input.stories.ts
@@ -26,6 +26,26 @@ export default {
         'The type of input. Works the same as a native `<input>` element, but only a subset of types are supported. ',
       control: 'select',
       options: ['date', 'datetime-local', 'email', 'number', 'password', 'search', 'tel', 'text', 'time', 'url', 'text']
+    },
+    'min-attr': {
+      name: 'min',
+      table: {
+        category: 'attributes',
+        defaultValue: ''
+      },
+      description:
+        "The input's minimum value. Only applies to date and number input types. String format for date  is yyyy-mm-dd",
+      control: 'text'
+    },
+    'max-attr': {
+      name: 'max',
+      table: {
+        category: 'attributes',
+        defaultValue: ''
+      },
+      description:
+        "The input's maximum value. Only applies to date and number input types. String format for date  is yyyy-mm-dd",
+      control: 'text'
     }
   },
   parameters: {

--- a/packages/components/src/components/input/input.test.ts
+++ b/packages/components/src/components/input/input.test.ts
@@ -82,16 +82,23 @@ describe('<sd-input>', () => {
   });
 
   describe('value min & max', () => {
-    it('should react on value within of range form date', async () => {
+    it('should react with data-valid attribute on input field when date value is within min-max range of date', async () => {
       const el = await fixture<SdInput>(html`
-        <sd-input type="date" value="2023-06-10" max="2024-06-10" spellcheck></sd-input>
+        <sd-input type="date" value="2024-06-10" min="2023-06-10" max="2025-06-10" spellcheck></sd-input>
       `);
       expect(el.hasAttribute('data-valid')).to.be.true;
     });
 
-    it('should react on value out of range form date', async () => {
+    it('should react with data-invalid attribute on input field when date value is greater then set maximum', async () => {
       const el = await fixture<SdInput>(html`
         <sd-input type="date" value="2025-06-10" max="2024-06-10" spellcheck></sd-input>
+      `);
+      expect(el.hasAttribute('data-invalid')).to.be.true;
+    });
+
+    it('should react with data-invalid attribute on input field when date value is lower then set minimum', async () => {
+      const el = await fixture<SdInput>(html`
+        <sd-input type="date" value="2023-06-10" min="2024-06-10" spellcheck></sd-input>
       `);
       expect(el.hasAttribute('data-invalid')).to.be.true;
     });

--- a/packages/components/src/components/input/input.test.ts
+++ b/packages/components/src/components/input/input.test.ts
@@ -81,6 +81,32 @@ describe('<sd-input>', () => {
     });
   });
 
+  describe('value min & max', () => {
+    it('should react on value within of range form date', async () => {
+      const el = await fixture<SdInput>(html`
+        <sd-input type="date" value="2023-06-10" max="2024-06-10" spellcheck></sd-input>
+      `);
+      expect(el.hasAttribute('data-valid')).to.be.true;
+    });
+
+    it('should react on value out of range form date', async () => {
+      const el = await fixture<SdInput>(html`
+        <sd-input type="date" value="2025-06-10" max="2024-06-10" spellcheck></sd-input>
+      `);
+      expect(el.hasAttribute('data-invalid')).to.be.true;
+    });
+
+    it('should react on value within/out of range form number', async () => {
+      const el = await fixture<SdInput>(html` <sd-input type="number" min="5" spellcheck></sd-input> `);
+      el.valueAsNumber = 6;
+      expect(el.checkValidity()).to.be.true;
+
+      el.valueAsNumber = 4;
+      await el.updateComplete;
+      expect(el.checkValidity()).to.be.false;
+    });
+  });
+
   it('should focus the input when clicking on the label', async () => {
     const el = await fixture<SdInput>(html` <sd-input label="Name"></sd-input> `);
     const label = el.shadowRoot!.querySelector('[part~="form-control-label"]')!;

--- a/packages/components/src/components/input/input.ts
+++ b/packages/components/src/components/input/input.ts
@@ -156,10 +156,10 @@ export default class SdInput extends SolidElement implements SolidFormControl {
   @property({ type: Number }) maxlength: number;
 
   /** The input's minimum value. Only applies to date and number input types. */
-  @property({ type: Number }) min: number;
+  @property() min: number | string;
 
   /** The input's maximum value. Only applies to date and number input types. */
-  @property({ type: Number }) max: number;
+  @property() max: number | string;
 
   /**
    * By default, form controls are associated with the nearest containing `<form>` element. This attribute allows you

--- a/packages/components/src/internal/solid-element.ts
+++ b/packages/components/src/internal/solid-element.ts
@@ -47,8 +47,8 @@ export interface SolidFormControl extends SolidElement {
 
   // Standard validation attributes
   pattern?: string;
-  min?: number | Date;
-  max?: number | Date;
+  min?: number | Date | string;
+  max?: number | Date | string;
   step?: number | 'any';
   required?: boolean;
   minlength?: number;


### PR DESCRIPTION


<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
input type - date : min and max properties (of type type of string) was added so that type of input:Date can also use those properties.

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
- [x] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
