### PR TITLE
fix: #1193 correct clear button color in sd-icon and sd-select

### DIFF
--- a/packages/components/src/components/input/input.ts
+++ b/packages/components/src/components/input/input.ts
@@ -454,10 +454,10 @@ export default class SdInput extends SolidElement implements SolidFormControl {
       disabled: 'text-neutral-500',
       readonly: 'text-black',
       activeInvalid: 'text-error',
-      activeValid: 'text-success',
+      activeValid: 'text-black',
       active: 'text-black',
       invalid: 'text-error',
-      valid: 'text-success',
+      valid: 'text-black',
       default: 'text-black'
     }[inputState];
 

--- a/packages/components/src/components/input/input.ts
+++ b/packages/components/src/components/input/input.ts
@@ -566,7 +566,7 @@ export default class SdInput extends SolidElement implements SolidFormControl {
                   >
                     <slot name="clear-icon">
                       <sd-icon
-                        class=${cx('text-neutral-800', iconSize)}
+                        class=${cx('icon-fill-neutral-800', iconSize)}
                         library="system"
                         name="closing-round"
                       ></sd-icon>

--- a/packages/components/src/components/input/input.ts
+++ b/packages/components/src/components/input/input.ts
@@ -554,7 +554,6 @@ export default class SdInput extends SolidElement implements SolidFormControl {
               @focus=${this.handleFocus}
               @blur=${this.handleBlur}
             />
-            <!-- TODO: substitute text-neutral-400 for text-neutral-500 when available! -->
             ${hasClearIcon
               ? html`
                   <button
@@ -567,7 +566,7 @@ export default class SdInput extends SolidElement implements SolidFormControl {
                   >
                     <slot name="clear-icon">
                       <sd-icon
-                        class=${cx('text-neutral-500', iconSize)}
+                        class=${cx('text-neutral-800', iconSize)}
                         library="system"
                         name="closing-round"
                       ></sd-icon>

--- a/packages/components/src/components/select/select.ts
+++ b/packages/components/src/components/select/select.ts
@@ -967,7 +967,7 @@ export default class SdSelect extends SolidElement implements SolidFormControl {
                     >
                       <slot name="clear-icon">
                         <sd-icon
-                          class=${cx('text-neutral-500', iconSize)}
+                          class=${cx('text-neutral-800', iconSize)}
                           library="system"
                           name="closing-round"
                         ></sd-icon>

--- a/packages/components/src/components/select/select.ts
+++ b/packages/components/src/components/select/select.ts
@@ -967,7 +967,7 @@ export default class SdSelect extends SolidElement implements SolidFormControl {
                     >
                       <slot name="clear-icon">
                         <sd-icon
-                          class=${cx('text-neutral-800', iconSize)}
+                          class=${cx('text-icon-fill-neutral-800', iconSize)}
                           library="system"
                           name="closing-round"
                         ></sd-icon>


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
Change "clear button' color in sd-input and sd-select from neutral-500 to neutral-800.
Change "valid input" text color from green to default text color for accessibility.

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [x] Documentation is created/updated
- [x] Migration Guide is created/updated
- [x] E2E tests (features, a11y, bug fixes) are created/updated
- [x] Stories (features, a11y) are created/updated
- [x] relevant tickets are linked
