### PR TITLE
fix: pass empty download attr to "a" tag in sd-link

### DIFF
--- a/packages/components/src/components/link/link.test.ts
+++ b/packages/components/src/components/link/link.test.ts
@@ -65,4 +65,21 @@ describe('<sd-link>', () => {
       expect(clickHandler).to.have.been.calledOnce;
     });
   });
+  describe('download attribute', () => {
+    it('should be set on the <a> tag when a value is provided', async () => {
+      const el = await fixture<SdLink>(html` <sd-link href="#" download="file.txt">Default Slot</sd-link> `);
+      const a = el.shadowRoot!.querySelector('a')!;
+      expect(a).to.have.attribute('download', 'file.txt');
+    });
+    it('should not be set on the <a> tag when no value is provided', async () => {
+      const el = await fixture<SdLink>(html` <sd-link href="#">Default Slot</sd-link> `);
+      const a = el.shadowRoot!.querySelector('a')!;
+      expect(a).to.not.have.attribute('download');
+    });
+    it('should set the download attribute with empty string when no value is provided', async () => {
+      const el = await fixture<SdLink>(html` <sd-link href="#" download="">Default Slot</sd-link> `);
+      const a = el.shadowRoot!.querySelector('a')!;
+      expect(a).to.have.attribute('download', '');
+    });
+  });
 });

--- a/packages/components/src/components/link/link.ts
+++ b/packages/components/src/components/link/link.ts
@@ -93,7 +93,7 @@ export default class SdLink extends SolidElement {
       )}
       href=${ifDefined(this.href || undefined)}
       target=${ifDefined(this.target || undefined)}
-      download=${ifDefined(this.download || undefined)}
+      download=${ifDefined(this.download)}
       rel=${ifDefined(this.target ? 'noreferrer noopener' : undefined)}
       aria-disabled=${!this.href ? 'true' : 'false'}
       tabindex=${!this.href ? '-1' : '0'}


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
#1222 

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
