### PR TITLE
feat: ✨ enable usage of link with children on sd-navigation-item

### DIFF
--- a/packages/components/src/components/navigation-item/navigation-item.stories.ts
+++ b/packages/components/src/components/navigation-item/navigation-item.stories.ts
@@ -273,7 +273,7 @@ export const Chevron = {
  */
 
 export const IndentedRelaxed = {
-  name: 'Indented × Relaxed',
+  name: 'Indented x Relaxed',
   parameters: {
     controls: {
       exclude: ['vertical', 'chevron', 'indented', 'sd-show', 'sd-hide']
@@ -460,5 +460,41 @@ export const Mouseless = {
     await waitUntil(() => el?.shadowRoot?.querySelector('button'));
 
     el?.shadowRoot?.querySelector('button')?.focus();
+  }
+};
+
+export const separated = {
+  render: () => {
+    return generateTemplate({
+      args: overrideArgs([
+        defaultSlotConstant,
+        {
+          type: 'attribute',
+          name: 'vertical',
+          value: true
+        },
+        {
+          type: 'attribute',
+          name: 'separated',
+          value: true
+        },
+        {
+          type: 'attribute',
+          name: 'href',
+          value: 'https://www.union-investment.de/'
+        },
+        {
+          type: 'attribute',
+          name: 'chevron',
+          value: true
+        },
+        {
+          type: 'slot',
+          name: 'children',
+          value: '<div slot="children" class="slot slot--border slot--background h-6"></div>'
+        },
+        childrenSlotConstant
+      ])
+    });
   }
 };

--- a/packages/components/src/components/navigation-item/navigation-item.stories.ts
+++ b/packages/components/src/components/navigation-item/navigation-item.stories.ts
@@ -273,7 +273,7 @@ export const Chevron = {
  */
 
 export const IndentedRelaxed = {
-  name: 'Indented x Relaxed',
+  name: 'Indented × Relaxed',
   parameters: {
     controls: {
       exclude: ['vertical', 'chevron', 'indented', 'sd-show', 'sd-hide']

--- a/packages/components/src/components/navigation-item/navigation-item.stories.ts
+++ b/packages/components/src/components/navigation-item/navigation-item.stories.ts
@@ -299,6 +299,47 @@ export const IndentedRelaxed = {
 };
 
 /**
+ * With `separated` attribute, the navigation item will have more that only one action. It is possible to use it as a link and an accordion simultaneously.
+ *
+ * It needs a children slot and an href.
+ */
+export const separated = {
+  render: () => {
+    return generateTemplate({
+      args: overrideArgs([
+        defaultSlotConstant,
+        {
+          type: 'attribute',
+          name: 'vertical',
+          value: true
+        },
+        {
+          type: 'attribute',
+          name: 'separated',
+          value: true
+        },
+        {
+          type: 'attribute',
+          name: 'href',
+          value: 'https://www.union-investment.de/'
+        },
+        {
+          type: 'attribute',
+          name: 'chevron',
+          value: true
+        },
+        {
+          type: 'slot',
+          name: 'children',
+          value: '<div slot="children" class="slot slot--border slot--background h-6"></div>'
+        },
+        childrenSlotConstant
+      ])
+    });
+  }
+};
+
+/**
  * Shows available slots.  `description`is only used when `vertical`is true.
  */
 
@@ -431,7 +472,7 @@ export const Parts = {
 export const Mouseless = {
   render: (args: any) => {
     return html`<div class="mouseless">
-      ${['Button', 'Link', 'Accordion'].map(title => {
+      ${['Button', 'Link', 'Accordion', 'Separated'].map(title => {
         const constants: ConstantDefinition[] = [
           { type: 'attribute', name: 'vertical', value: true },
           { type: 'attribute', name: 'chevron', value: true },
@@ -445,6 +486,12 @@ export const Mouseless = {
         if (title === 'Link')
           constants.push({ type: 'attribute', name: 'href', value: 'https://www.union-investment.de/' });
         if (title === 'Accordion') constants.push(childrenSlotConstant);
+        if (title === 'Separated')
+          constants.push(
+            { type: 'attribute', name: 'separated', value: true },
+            { type: 'attribute', name: 'href', value: 'https://www.union-investment.de/' },
+            childrenSlotConstant
+          );
 
         return generateTemplate({
           args,
@@ -460,41 +507,5 @@ export const Mouseless = {
     await waitUntil(() => el?.shadowRoot?.querySelector('button'));
 
     el?.shadowRoot?.querySelector('button')?.focus();
-  }
-};
-
-export const separated = {
-  render: () => {
-    return generateTemplate({
-      args: overrideArgs([
-        defaultSlotConstant,
-        {
-          type: 'attribute',
-          name: 'vertical',
-          value: true
-        },
-        {
-          type: 'attribute',
-          name: 'separated',
-          value: true
-        },
-        {
-          type: 'attribute',
-          name: 'href',
-          value: 'https://www.union-investment.de/'
-        },
-        {
-          type: 'attribute',
-          name: 'chevron',
-          value: true
-        },
-        {
-          type: 'slot',
-          name: 'children',
-          value: '<div slot="children" class="slot slot--border slot--background h-6"></div>'
-        },
-        childrenSlotConstant
-      ])
-    });
   }
 };

--- a/packages/components/src/components/navigation-item/navigation-item.test.ts
+++ b/packages/components/src/components/navigation-item/navigation-item.test.ts
@@ -208,7 +208,7 @@ describe('<sd-navigation-item>', () => {
     // Events
     it('emits "sd-show" event when clicking closed HTML details element summary', async () => {
       const el = await fixture<SdNavigationItem>(variants.accordion.default);
-      console.log(el.shadowRoot);
+
       const details = el.shadowRoot!.querySelector('details');
       const summary = el.shadowRoot!.querySelector('summary');
       const clickHandler = sinon.spy();

--- a/packages/components/src/components/navigation-item/navigation-item.test.ts
+++ b/packages/components/src/components/navigation-item/navigation-item.test.ts
@@ -208,6 +208,7 @@ describe('<sd-navigation-item>', () => {
     // Events
     it('emits "sd-show" event when clicking closed HTML details element summary', async () => {
       const el = await fixture<SdNavigationItem>(variants.accordion.default);
+      console.log(el.shadowRoot);
       const details = el.shadowRoot!.querySelector('details');
       const summary = el.shadowRoot!.querySelector('summary');
       const clickHandler = sinon.spy();
@@ -296,27 +297,26 @@ describe('<sd-navigation-item>', () => {
     });
   });
 
-  // // Test separate variant
-  // describe('when given a value for the "children" slot, an "href" property and "separate" property is true', () => {
-  //   it('renders a div with an open slot and a link in separate divs', async () => {
-  //     console.log('here');
-  //     // const el = await fixture<SdNavigationItem>(variants.link.children);
-  //     // console.log(el);
+  // Test separate variant
+  describe('when given a value for the "children" slot, an "href" property and "separate" property is true', () => {
+    it('renders a div with an open slot and a link in separate div', async () => {
+      const el = await fixture<SdNavigationItem>(
+        html`<sd-navigation-item separated href="#" vertical chevron>Navigation</sd-navigation-item>`
+      );
 
-  //     // console.log(el.shadowRoot);
-  //     // expect(el).to.exist;
-  //     // expect(el.shadowRoot!.querySelector('a')).to.not.exist;
-  //     // expect(el.shadowRoot!.querySelector('button')).to.exist;
-  //     // expect(el.shadowRoot!.querySelector('summary')).to.not.exist;
-  //     // expect(el.shadowRoot!.querySelector('details')).to.not.exist;
-  //   });
+      expect(el).to.exist;
+      expect(el.shadowRoot!.querySelector('a')).to.exist;
+      expect(el.shadowRoot!.querySelector('button')).to.exist;
+      expect(el.shadowRoot!.querySelector('summary')).to.not.exist;
+      expect(el.shadowRoot!.querySelector('details')).to.not.exist;
+    });
 
-  //   //Accessibility
-  //   it('passes accessibility test', async () => {
-  //     const el = await fixture<SdNavigationItem>(
-  //       html`<sd-navigation-item href="#" separated>${defaultSlot}${childrenSlot}</sd-navigation-item>`
-  //     );
-  //     await expect(el).to.be.accessible();
-  //   });
-  // });
+    //Accessibility
+    it('passes accessibility test', async () => {
+      const el = await fixture<SdNavigationItem>(
+        html`<sd-navigation-item href="#" separated>${defaultSlot}${childrenSlot}</sd-navigation-item>`
+      );
+      await expect(el).to.be.accessible();
+    });
+  });
 });

--- a/packages/components/src/components/navigation-item/navigation-item.test.ts
+++ b/packages/components/src/components/navigation-item/navigation-item.test.ts
@@ -299,9 +299,23 @@ describe('<sd-navigation-item>', () => {
 
   // Test separate variant
   describe('when given a value for the "children" slot, an "href" property and "separate" property is true', () => {
-    it('renders a div with an open slot and a link in separate div', async () => {
+    it('renders an accordion with a link simultaneously', async () => {
       const el = await fixture<SdNavigationItem>(
         html`<sd-navigation-item separated href="#" vertical chevron>Navigation</sd-navigation-item>`
+      );
+
+      expect(el).to.exist;
+      expect(el.shadowRoot!.querySelector('a')).to.exist;
+      expect(el.shadowRoot!.querySelector('button')).to.exist;
+      expect(el.shadowRoot!.querySelector('summary')).to.not.exist;
+      expect(el.shadowRoot!.querySelector('details')).to.not.exist;
+    });
+
+    it('renders an open accordion with children slot and a link simultaneously', async () => {
+      const el = await fixture<SdNavigationItem>(
+        html`<sd-navigation-item separated href="#" vertical chevron open
+          >Navigation${childrenSlot}</sd-navigation-item
+        >`
       );
 
       expect(el).to.exist;

--- a/packages/components/src/components/navigation-item/navigation-item.test.ts
+++ b/packages/components/src/components/navigation-item/navigation-item.test.ts
@@ -1,4 +1,5 @@
 import { expect, fixture, html, waitUntil } from '@open-wc/testing';
+import { it } from 'mocha';
 import sinon from 'sinon';
 import type SdNavigationItem from './navigation-item';
 
@@ -104,7 +105,7 @@ describe('<sd-navigation-item>', () => {
   // Test overriding link variant
   describe('when given an "href" property', () => {
     // Render
-    it('only renders an anchor element, regardless of children', async () => {
+    it('only renders an anchor element regardless of children', async () => {
       const el = await fixture<SdNavigationItem>(variants.link.children);
 
       expect(el).to.exist;
@@ -293,6 +294,31 @@ describe('<sd-navigation-item>', () => {
 
         expect(hideHandler.calledOnce).to.be.false;
       });
+    });
+  });
+
+  // Test separate variant
+  describe('when given a value for the "children" slot, an "href" property and "separate" property is true', () => {
+    it('renders a div with slot closed and a link in a separate div', async () => {
+      const el = await fixture<SdNavigationItem>(
+        html`<sd-navigation-item href="#" separate>${defaultSlot}${childrenSlot}</sd-navigation-item>`
+      );
+
+      expect(el).to.exist;
+      expect(el.shadowRoot!.querySelector('a')).to.exist;
+      expect(el.shadowRoot!.querySelector('button')).to.exist;
+      expect(el.shadowRoot!.querySelector('summary')).to.not.exist;
+      expect(el.shadowRoot!.querySelector('details')).to.not.exist;
+      expect(el.shadowRoot!.querySelector('div[slot="children"]')).to.exist;
+      expect(el.shadowRoot!.querySelector('div[slot="children"] a')).to.exist;
+    });
+
+    //Accessibility
+    it('passes accessibility test', async () => {
+      const el = await fixture<SdNavigationItem>(
+        html`<sd-navigation-item href="#" separate>${defaultSlot}${childrenSlot}</sd-navigation-item>`
+      );
+      await expect(el).to.be.accessible();
     });
   });
 });

--- a/packages/components/src/components/navigation-item/navigation-item.test.ts
+++ b/packages/components/src/components/navigation-item/navigation-item.test.ts
@@ -1,5 +1,4 @@
 import { expect, fixture, html, waitUntil } from '@open-wc/testing';
-import { it } from 'mocha';
 import sinon from 'sinon';
 import type SdNavigationItem from './navigation-item';
 
@@ -297,28 +296,27 @@ describe('<sd-navigation-item>', () => {
     });
   });
 
-  // Test separate variant
-  describe('when given a value for the "children" slot, an "href" property and "separate" property is true', () => {
-    it('renders a div with slot closed and a link in a separate div', async () => {
-      const el = await fixture<SdNavigationItem>(
-        html`<sd-navigation-item href="#" separate>${defaultSlot}${childrenSlot}</sd-navigation-item>`
-      );
+  // // Test separate variant
+  // describe('when given a value for the "children" slot, an "href" property and "separate" property is true', () => {
+  //   it('renders a div with an open slot and a link in separate divs', async () => {
+  //     console.log('here');
+  //     // const el = await fixture<SdNavigationItem>(variants.link.children);
+  //     // console.log(el);
 
-      expect(el).to.exist;
-      expect(el.shadowRoot!.querySelector('a')).to.exist;
-      expect(el.shadowRoot!.querySelector('button')).to.exist;
-      expect(el.shadowRoot!.querySelector('summary')).to.not.exist;
-      expect(el.shadowRoot!.querySelector('details')).to.not.exist;
-      expect(el.shadowRoot!.querySelector('div[slot="children"]')).to.exist;
-      expect(el.shadowRoot!.querySelector('div[slot="children"] a')).to.exist;
-    });
+  //     // console.log(el.shadowRoot);
+  //     // expect(el).to.exist;
+  //     // expect(el.shadowRoot!.querySelector('a')).to.not.exist;
+  //     // expect(el.shadowRoot!.querySelector('button')).to.exist;
+  //     // expect(el.shadowRoot!.querySelector('summary')).to.not.exist;
+  //     // expect(el.shadowRoot!.querySelector('details')).to.not.exist;
+  //   });
 
-    //Accessibility
-    it('passes accessibility test', async () => {
-      const el = await fixture<SdNavigationItem>(
-        html`<sd-navigation-item href="#" separate>${defaultSlot}${childrenSlot}</sd-navigation-item>`
-      );
-      await expect(el).to.be.accessible();
-    });
-  });
+  //   //Accessibility
+  //   it('passes accessibility test', async () => {
+  //     const el = await fixture<SdNavigationItem>(
+  //       html`<sd-navigation-item href="#" separated>${defaultSlot}${childrenSlot}</sd-navigation-item>`
+  //     );
+  //     await expect(el).to.be.accessible();
+  //   });
+  // });
 });

--- a/packages/components/src/components/navigation-item/navigation-item.ts
+++ b/packages/components/src/components/navigation-item/navigation-item.ts
@@ -274,13 +274,7 @@ export default class SdNavigationItem extends SolidElement {
       </details>`;
     }
     if (this.separated) {
-      return html`<div
-        part="details"
-        id="navigation-item-details"
-        ?open=${this.open}
-        class="relative flex flex-col"
-        tabindex="-1"
-      >
+      return html`<div part="details" id="navigation-item-details" class="relative flex flex-col">
         ${root}${this.open ? html`<slot name="children"></slot>` : ''}
       </div>`;
     }

--- a/packages/components/src/components/navigation-item/navigation-item.ts
+++ b/packages/components/src/components/navigation-item/navigation-item.ts
@@ -121,7 +121,7 @@ export default class SdNavigationItem extends SolidElement {
     return '';
   }
 
-  private get rootTag() {
+  private get tag() {
     if (this.isAccordion() && !this.isLink()) {
       return literal`summary`;
     }
@@ -151,7 +151,7 @@ export default class SdNavigationItem extends SolidElement {
     /* eslint-disable lit/no-invalid-html */
     /* eslint-disable lit/binding-positions */
     const root = html`
-      <${this.rootTag}
+      <${this.tag}
         part="base"
         class=${cx(
           'cursor-pointer relative focus-visible:focus-outline',
@@ -263,7 +263,7 @@ export default class SdNavigationItem extends SolidElement {
               ></slot>`
             : ''
         }
-      </${this.rootTag}>
+      </${this.tag}>
     `;
     /* eslint-enable lit/no-invalid-html */
     /* eslint-enable lit/binding-positions */

--- a/packages/components/src/components/navigation-item/navigation-item.ts
+++ b/packages/components/src/components/navigation-item/navigation-item.ts
@@ -1,4 +1,4 @@
-import { css } from 'lit';
+import { css, unsafeCSS } from 'lit';
 import { customElement } from '../../internal/register-custom-element';
 import { HasSlotController } from '../../internal/slot';
 import { html, literal } from 'lit/static-html.js';
@@ -6,6 +6,7 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 import { property } from 'lit/decorators.js';
 import componentStyles from '../../styles/component.styles';
 import cx from 'classix';
+import InteractiveStyles from '../../styles/interactive/interactive.css?inline';
 import SolidElement from '../../internal/solid-element';
 
 /**
@@ -217,11 +218,10 @@ export default class SdNavigationItem extends SolidElement {
           ${
             (this.chevron || slots['children']) && this.vertical
               ? this.separated
-                ? html`<sd-button
-                    variant="tertiary"
+                ? html`<button
                     type="button"
-                    role="button"
                     title="chevron-down-button"
+                    class="sd-interactive sd-interactive--reset"
                     @click=${this.handleClickSummary}
                   >
                     <sd-icon
@@ -235,7 +235,7 @@ export default class SdNavigationItem extends SolidElement {
                         isAccordion || this.separated ? (this.open ? 'rotate-180' : 'rotate-0') : 'rotate-[270deg]'
                       )}
                     ></sd-icon>
-                  </sd-button>`
+                  </button>`
                 : html` <sd-icon
                     name="chevron-down"
                     part="chevron"
@@ -294,7 +294,7 @@ export default class SdNavigationItem extends SolidElement {
   static styles = [
     componentStyles,
     SolidElement.styles,
-
+    unsafeCSS(InteractiveStyles),
     css`
       :host {
         @apply inline-block relative box-border;

--- a/packages/components/src/components/navigation-item/navigation-item.ts
+++ b/packages/components/src/components/navigation-item/navigation-item.ts
@@ -204,7 +204,8 @@ export default class SdNavigationItem extends SolidElement {
               this.separated
                 ? html`<a
                     class=${cx(
-                      'w-full inline-flex items-center px-4 cursor-pointer relative focus-visible:focus-outline hover:bg-neutral-200 group transition-all min-h-[48px]'
+                      'w-full inline-flex items-center px-4 cursor-pointer relative focus-visible:focus-outline hover:bg-neutral-200 group transition-all min-h-[48px]',
+                      !slots['description'] && 'py-4'
                     )}
                     href=${ifDefined(isLink ? this.href : undefined)}
                     target=${ifDefined(isLink ? this.target : undefined)}

--- a/packages/components/src/components/navigation-item/navigation-item.ts
+++ b/packages/components/src/components/navigation-item/navigation-item.ts
@@ -205,7 +205,7 @@ export default class SdNavigationItem extends SolidElement {
               this.separated
                 ? html`<a
                     class=${cx(
-                      'w-full inline-flex items-center px-4 cursor-pointer relative focus-visible:focus-outline hover:bg-neutral-200 group transition-all min-h-[48px]',
+                      'mr-4 w-full inline-flex items-center pl-4 cursor-pointer relative focus-visible:focus-outline hover:bg-neutral-200 group transition-all min-h-[48px]',
                       !slots['description'] && 'py-4'
                     )}
                     href=${ifDefined(isLink ? this.href : undefined)}
@@ -232,7 +232,7 @@ export default class SdNavigationItem extends SolidElement {
                       library="system"
                       color="currentColor"
                       class=${cx(
-                        'h-6 w-6 transition-all',
+                        'mr-4 h-6 w-6 transition-all',
                         isAccordion || this.separated ? (this.open ? 'rotate-180' : 'rotate-0') : 'rotate-[270deg]'
                       )}
                     ></sd-icon>

--- a/packages/components/src/components/navigation-item/navigation-item.ts
+++ b/packages/components/src/components/navigation-item/navigation-item.ts
@@ -278,7 +278,7 @@ export default class SdNavigationItem extends SolidElement {
         part="details"
         id="navigation-item-details"
         ?open=${this.open}
-        class="relative flex flex-col px-4"
+        class="relative flex flex-col"
         tabindex="-1"
       >
         ${root}${this.open ? html`<slot name="children"></slot>` : ''}

--- a/packages/components/src/components/navigation-item/navigation-item.ts
+++ b/packages/components/src/components/navigation-item/navigation-item.ts
@@ -73,15 +73,15 @@ export default class SdNavigationItem extends SolidElement {
 
   @property({ type: Boolean, reflect: true }) separated = false;
 
-  private isButton(): boolean {
+  private get isButton(): boolean {
     return !this.href && !this.hasSlotController.test('children');
   }
 
-  private isLink(): boolean {
+  private get isLink(): boolean {
     return !!this.href;
   }
 
-  private isAccordion(): boolean {
+  private get isAccordion(): boolean {
     return !this.href && this.hasSlotController.test('children');
   }
 
@@ -115,7 +115,7 @@ export default class SdNavigationItem extends SolidElement {
     this.emit('sd-show', { cancelable: true });
   }
 
-  private calculatePaddingX(): string {
+  private get calculatePaddingX(): string {
     if (this.relaxed && this.indented) return 'pl-8 pr-4';
     if (this.relaxed) return 'px-4';
     if (this.indented) return 'pl-4';
@@ -123,22 +123,22 @@ export default class SdNavigationItem extends SolidElement {
   }
 
   private get tag() {
-    if (this.isAccordion() && !this.isLink()) {
+    if (this.isAccordion && !this.isLink) {
       return literal`summary`;
     }
     if (this.separated) {
       return literal`div`;
     }
-    if (this.isLink()) {
+    if (this.isLink) {
       return literal`a`;
     }
     return literal`button`;
   }
 
   render() {
-    const isLink = this.isLink();
-    const isButton = this.isButton();
-    const isAccordion = this.isAccordion();
+    const isLink = this.isLink;
+    const isButton = this.isButton;
+    const isAccordion = this.isAccordion;
 
     const slots = {
       label: this.hasSlotController.test('[default]'),
@@ -171,9 +171,9 @@ export default class SdNavigationItem extends SolidElement {
         target=${ifDefined(isLink ? this.target : undefined)}
         download=${ifDefined(isLink ? this.download : undefined)}
         rel=${ifDefined(isLink && this.target ? 'noreferrer noopener' : undefined)}
-        role=${!this.separated ? (isLink ? 'link' : 'button') : 'null'}
+        role=${isLink ? 'link' : 'button'}
         tabindex=${this.disabled || this.separated ? '-1' : '0'}
-        @click=${!this.separated ? (isAccordion ? this.handleClickSummary : isButton ? this.handleClickButton : undefined) : undefined}
+        @click=${this.separated ? undefined : isAccordion ? this.handleClickSummary : isButton ? this.handleClickButton : undefined}
       >
         <div
         part="current-indicator"
@@ -189,13 +189,13 @@ export default class SdNavigationItem extends SolidElement {
           'relative pt-3 inline-flex justify-between items-center',
           isAccordion ? 'grow' : 'w-full',
           slots['description'] || this.separated ? 'pb-1' : horizontalPaddingBottom,
-          this.calculatePaddingX()
+          this.calculatePaddingX
         )}>
           ${
             this.divider && this.vertical
               ? html`<sd-divider
                   part="divider"
-                  class=${cx('w-full transition-all absolute -top-0.25 left-0', this.calculatePaddingX())}
+                  class=${cx('w-full transition-all absolute -top-0.25 left-0', this.calculatePaddingX)}
                 ></sd-divider>`
               : ''
           }
@@ -230,7 +230,6 @@ export default class SdNavigationItem extends SolidElement {
                       part="chevron"
                       library="system"
                       color="currentColor"
-                      tabindex="-1"
                       class=${cx(
                         'h-6 w-6 transition-all',
                         isAccordion || this.separated ? (this.open ? 'rotate-180' : 'rotate-0') : 'rotate-[270deg]'
@@ -258,7 +257,7 @@ export default class SdNavigationItem extends SolidElement {
                 class=${cx(
                   'inline-block text-sm text-left text-black',
                   isAccordion || this.separated ? 'grow' : 'w-full',
-                  this.separated ? 'px-4' : this.calculatePaddingX(),
+                  this.separated ? 'px-4' : this.calculatePaddingX,
                   horizontalPaddingBottom
                 )}
               ></slot>`

--- a/packages/components/src/components/navigation-item/navigation-item.ts
+++ b/packages/components/src/components/navigation-item/navigation-item.ts
@@ -136,6 +136,7 @@ export default class SdNavigationItem extends SolidElement {
   }
 
   render() {
+    const tag = this.tag;
     const isLink = this.isLink;
     const isButton = this.isButton;
     const isAccordion = this.isAccordion;
@@ -152,7 +153,7 @@ export default class SdNavigationItem extends SolidElement {
     /* eslint-disable lit/no-invalid-html */
     /* eslint-disable lit/binding-positions */
     const root = html`
-      <${this.tag}
+      <${tag}
         part="base"
         class=${cx(
           'cursor-pointer relative focus-visible:focus-outline',
@@ -263,7 +264,7 @@ export default class SdNavigationItem extends SolidElement {
               ></slot>`
             : ''
         }
-      </${this.tag}>
+      </${tag}>
     `;
     /* eslint-enable lit/no-invalid-html */
     /* eslint-enable lit/binding-positions */


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
Ticket for [#344](https://github.com/orgs/solid-design-system/projects/1/views/54?pane=issue&itemId=55679158).
Added _separated_ property. When true, instead of summary and details, two divs will be rendered, containing a sd-link and a sd-button.

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [x] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [x] E2E tests (features, a11y, bug fixes) are created/updated
- [x] Stories (features, a11y) are created/updated
- [x] relevant tickets are linked
