### PR TITLE
feat: hide first default story in styles [skip chromatic]

### DIFF
--- a/packages/components/.storybook/preview-head.html
+++ b/packages/components/.storybook/preview-head.html
@@ -140,4 +140,8 @@
   h2#stories + [id^='anchor--components-'].sb-anchor {
     display: none;
   }
+
+  h2#stories + [id^='anchor--styles-'].sb-anchor {
+    display: none;
+  }
 </style>

--- a/packages/components/.storybook/preview-head.html
+++ b/packages/components/.storybook/preview-head.html
@@ -137,11 +137,7 @@
     display: none;
   }
 
-  h2#stories + [id^='anchor--components-'].sb-anchor {
-    display: none;
-  }
-
+  h2#stories + [id^='anchor--components-'].sb-anchor,
   h2#stories + [id^='anchor--styles-'].sb-anchor {
     display: none;
   }
-</style>

--- a/packages/components/.storybook/preview-head.html
+++ b/packages/components/.storybook/preview-head.html
@@ -141,3 +141,4 @@
   h2#stories + [id^='anchor--styles-'].sb-anchor {
     display: none;
   }
+</style>


### PR DESCRIPTION
## Description:
Similar to the behaviour of the components will hide the "default" story preventing to have it duplicated to styles.

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
