### PR TITLE
docs: fix code previews for strings (closes #1264) [skip chromatic]

### DIFF
--- a/packages/components/.storybook/preview.js
+++ b/packages/components/.storybook/preview.js
@@ -87,7 +87,24 @@ export const parameters = {
   docs: {
     story: { inline: true },
     toc: true,
-    source: { transform: code => storybookUtilities.codeOptimizer(code), format: 'html' }
+    source: {
+      transform: code => {
+        let output = code;
+
+        // This fixes the usage of self built html`` string literals
+        if (output.trim().startsWith('&lt;')) {
+          output = output
+            .replace(/&lt;/g, '<')
+            .replace(/&gt;/g, '>')
+            .replace(/&amp;/g, '&')
+            .replace(/&quot;/g, '"')
+            .replace(/&#039;/g, "'");
+        }
+
+        return storybookUtilities.codeOptimizer(output);
+      },
+      format: 'html'
+    }
   },
   backgrounds: {
     default: 'white',


### PR DESCRIPTION
Testable on sd-prose → last sample


![CleanShot 2024-08-09 at 14 23 39@2x](https://github.com/user-attachments/assets/00297b92-e96e-4de4-a11f-7d9efc9fc241)

Old: https://solid-design-system.github.io/solid/main/?path=/docs/styles-sd-prose--docs
New: https://solid-design-system.github.io/solid/docs_fix-wrong-code-preview/?path=/docs/styles-sd-prose--docs