### PR TITLE
fix: neutral-100 should apply on readonly textarea

### DIFF
--- a/packages/components/src/components/textarea/textarea.ts
+++ b/packages/components/src/components/textarea/textarea.ts
@@ -364,7 +364,7 @@ export default class SdTextarea extends SolidElement implements SolidFormControl
           <div
             part="base"
             class=${cx(
-              'textarea px-4 flex items-top rounded-default bg-white group',
+              'textarea px-4 flex items-top rounded-default group',
               {
                 sm: 'textarea-sm py-1',
                 md: 'textarea-md py-1',
@@ -381,7 +381,7 @@ export default class SdTextarea extends SolidElement implements SolidFormControl
                 default: 'text-black'
               }[textareaState],
               !this.disabled && !this.readonly ? 'hover:bg-neutral-200' : '',
-              this.readonly && 'bg-neutral-100'
+              this.readonly ? 'bg-neutral-100' : 'bg-white'
             )}
           >
             <textarea


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
<!-- *PR notes: Please describe the changes in this PR.* -->
neutral-100 background style was overridden by the bg-white. Now neutral-100 is always applied when readonly is true.

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
