### PR TITLE
fix: correct readonly background styles for sd-input

### DIFF
--- a/packages/components/src/components/input/input.ts
+++ b/packages/components/src/components/input/input.ts
@@ -501,12 +501,12 @@ export default class SdInput extends SolidElement implements SolidFormControl {
           <div
             part="base"
             class=${cx(
-              'px-4 flex flex-row items-center rounded-default transition-all bg-white',
+              'px-4 flex flex-row items-center rounded-default transition-all',
               // Vertical Padding
               this.size === 'lg' ? 'py-2' : 'py-1',
               // States
               !this.disabled && !this.readonly ? 'hover:bg-neutral-200' : '',
-              this.readonly && 'bg-neutral-100',
+              this.readonly ? 'bg-neutral-100' : 'bg-white',
               textColor
             )}
           >


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
<!-- *PR notes: Please describe the changes in this PR.* -->
Fixed Background Color for read-only state.

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
