### PR TITLE
fix: make sd-step-group more accessible

### DIFF
--- a/packages/components/src/components/step/step.test.stories.ts
+++ b/packages/components/src/components/step/step.test.stories.ts
@@ -56,7 +56,17 @@ export const Orientation = {
       },
       args
     });
-  }
+  },
+  decorators: [
+    (story: () => typeof html) => html`
+      <style>
+        td.template {
+          height: 150px;
+        }
+      </style>
+      ${story()}
+    `
+  ]
 };
 
 /**

--- a/packages/components/src/components/step/step.ts
+++ b/packages/components/src/components/step/step.ts
@@ -127,7 +127,7 @@ export default class SdStep extends SolidElement {
           class=${cx(
             'flex shrink-0 gap-2',
             this.noTail && 'w-max',
-            this.orientation === 'horizontal' ? 'flex-row' : 'flex-col items-stretch',
+            this.orientation === 'horizontal' ? 'flex-row' : 'flex-col items-stretch h-full',
             this.orientation === 'horizontal'
               ? this.size === 'lg'
                 ? 'translateLg'
@@ -137,7 +137,7 @@ export default class SdStep extends SolidElement {
                 : 'mt-3'
           )}
         >
-          
+
           <${tag}
             part="circle"
             ?disabled=${this.disabled}
@@ -181,25 +181,19 @@ export default class SdStep extends SolidElement {
           ${
             this.noTail
               ? ''
-              : this.orientation === 'horizontal'
-                ? html`
-                    <sd-divider
-                      part="tail"
-                      orientation="horizontal"
-                      class=${cx(
-                        'w-full my-auto mr-2',
-                        !this.disabled && !this.current && !this.notInteractive && 'tail-to-primary'
-                      )}
-                    ></sd-divider>
-                  `
-                : html`<sd-divider
+              : html`
+                  <div
                     part="tail"
-                    orientation="vertical"
                     class=${cx(
-                      'flex-grow flex-shrink-0 basis-auto h-full w-[1px] mx-auto',
-                      !this.disabled && !this.current && !this.notInteractive && 'tail-to-primary'
+                      this.orientation === 'horizontal'
+                        ? 'border-t w-full my-auto mr-2'
+                        : 'border-l flex-grow flex-shrink-0 basis-auto h-full w-[1px] mx-auto',
+                      !this.disabled && !this.current && !this.notInteractive
+                        ? ' border-primary group-hover:border-primary-500'
+                        : 'border-neutral-400'
                     )}
-                  ></sd-divider> `
+                  ></div>
+                `
           }
         </div>
 
@@ -225,10 +219,6 @@ export default class SdStep extends SolidElement {
         @apply flex-1;
       }
 
-      [part='base']:not(:has(sd-divider)) {
-        @apply h-max;
-      }
-
       :host([no-tail]) {
         @apply flex-grow-0;
       }
@@ -239,14 +229,6 @@ export default class SdStep extends SolidElement {
 
       .translateSm {
         transform: translateX(64px);
-      }
-
-      .tail-to-primary::part(main) {
-        @apply !border-primary group-hover:!border-primary-500;
-      }
-
-      sd-divider::part(main) {
-        @apply !border-neutral-400;
       }
     `
   ];

--- a/packages/components/src/components/step/step.ts
+++ b/packages/components/src/components/step/step.ts
@@ -127,7 +127,7 @@ export default class SdStep extends SolidElement {
           class=${cx(
             'flex shrink-0 gap-2',
             this.noTail && 'w-max',
-            this.orientation === 'horizontal' ? 'flex-row' : 'flex-col items-stretch h-full',
+            this.orientation === 'horizontal' ? 'flex-row' : 'flex-col items-stretch',
             this.orientation === 'horizontal'
               ? this.size === 'lg'
                 ? 'translateLg'


### PR DESCRIPTION
## Description:
`sd-divider` was replaced with borders, as otherwise an `hr` would have been announced.

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
