### PR TITLE
fix: 🤔 missing border when sd-select has not enough space 

### DIFF
--- a/packages/components/src/components/select/select.test.stories.ts
+++ b/packages/components/src/components/select/select.test.stories.ts
@@ -34,6 +34,15 @@ const fiveOptionsConstant: ConstantDefinition = {
   value:
     '<sd-option value="option-1">Option 1</sd-option><sd-option value="option-2">Option 2</sd-option><sd-option value="option-3">Option 3</sd-option><sd-option value="option-4">Option 4</sd-option><sd-option value="option-5">Option 5</sd-option>'
 };
+
+const twentyOptionsConstant: ConstantDefinition = {
+  type: 'slot',
+  name: 'default',
+  value: `
+    ${Array.from({ length: 20 }, (_, i) => `<sd-option value="option-${i + 1}">Option ${i + 1}</sd-option>`).join('')}
+  `
+};
+
 const clearableConstant: ConstantDefinition = { type: 'attribute', name: 'clearable', value: true };
 const multipleConstant: ConstantDefinition = { type: 'attribute', name: 'multiple', value: true };
 const helpTextConstant: ConstantDefinition = { type: 'attribute', name: 'help-text', value: 'help-text' };
@@ -217,6 +226,26 @@ export const ValidInvalid = {
     const el = canvasElement.querySelector('sd-button');
     await waitUntil(() => el?.shadowRoot?.querySelector('button'));
     await userEvent.type(el!.shadowRoot!.querySelector('button')!, '{return}', { pointerEventsCheck: 0 });
+  }
+};
+
+/**
+ * This shows sd-select has the borders visible even when there is limited vertical space.
+ */
+
+export const BorderVisibility = {
+  name: 'Border Visibility',
+  render: () => {
+    return html`<div class="h-[150px] w-[420px]">
+      ${generateTemplate({
+        args: overrideArgs([
+          twentyOptionsConstant,
+          labelConstant,
+          { type: 'attribute', name: 'placeholder', value: 'Please Select' },
+          { type: 'attribute', name: 'max-options-visible', value: 3 }
+        ])
+      })}
+    </div>`;
   }
 };
 

--- a/packages/components/src/components/select/select.test.stories.ts
+++ b/packages/components/src/components/select/select.test.stories.ts
@@ -723,5 +723,6 @@ export const Combination = generateScreenshotStory([
   SampleGroupingOptions,
   SampleForm,
   setCustomValidity,
+  BorderVisibility,
   SolidForm
 ]);

--- a/packages/components/src/components/select/select.ts
+++ b/packages/components/src/components/select/select.ts
@@ -1006,7 +1006,7 @@ export default class SdSelect extends SolidElement implements SolidFormControl {
               aria-labelledby="label"
               part="listbox"
               class=${cx(
-                'bg-white px-2 py-3 relative border-primary',
+                'bg-white px-2 py-3 relative border-primary overflow-y-auto',
                 this.open && 'shadow',
                 this.currentPlacement === 'bottom'
                   ? 'border-r-2 border-b-2 border-l-2 rounded-br-default rounded-bl-default'
@@ -1047,6 +1047,10 @@ export default class SdSelect extends SolidElement implements SolidFormControl {
 
       :host([required]) #label::after {
         content: ' *';
+      }
+
+      [part='listbox'] {
+        max-height: var(--auto-size-available-height, auto);
       }
 
       sd-popup::part(popup) {


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
<!-- *PR notes: Please describe the changes in this PR.* -->
Limited the height of the listbox using an interesting CSS variable I found in the wrapping sd-popup :) 
`--auto-size-available-height`. Closes #1042. 


## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [x] relevant tickets are linked
