### PR TITLE
fix: 🤔 sd-textarea doesn't accept full height of container

### DIFF
--- a/packages/components/src/components/textarea/textarea.test.stories.ts
+++ b/packages/components/src/components/textarea/textarea.test.stories.ts
@@ -422,6 +422,21 @@ export const Parts = {
 };
 
 /**
+ * This shows sd-textarea takes the full height of the parent container.
+ */
+export const ResponsiveHeight = {
+  name: 'Responsive Height',
+  args: overrideArgs([
+    { type: 'attribute', name: 'label', value: 'Label' },
+    { type: 'attribute', name: 'value', value: 'value' },
+    { type: 'attribute', name: 'help-text', value: 'help-text' }
+  ]),
+  render: (args: any) => {
+    return html`<div class="w-[250px] h-[500px]">${generateTemplate({ args })}</div> `;
+  }
+};
+
+/**
  * `sd-textarea` is fully accessibile via keyboard.
  */
 

--- a/packages/components/src/components/textarea/textarea.test.stories.ts
+++ b/packages/components/src/components/textarea/textarea.test.stories.ts
@@ -336,6 +336,21 @@ export const setCustomValidity = {
 };
 
 /**
+ * This shows sd-textarea takes the full height of the parent container.
+ */
+export const ResponsiveHeight = {
+  name: 'Responsive Height',
+  args: overrideArgs([
+    { type: 'attribute', name: 'label', value: 'Label' },
+    { type: 'attribute', name: 'value', value: 'value' },
+    { type: 'attribute', name: 'help-text', value: 'help-text' }
+  ]),
+  render: (args: any) => {
+    return html`<div class="w-[250px] h-[500px]">${generateTemplate({ args })}</div> `;
+  }
+};
+
+/**
  * Shows available slots. The `label` and `help-text` slots will overwrite their corresponding attributes.
  */
 
@@ -422,21 +437,6 @@ export const Parts = {
 };
 
 /**
- * This shows sd-textarea takes the full height of the parent container.
- */
-export const ResponsiveHeight = {
-  name: 'Responsive Height',
-  args: overrideArgs([
-    { type: 'attribute', name: 'label', value: 'Label' },
-    { type: 'attribute', name: 'value', value: 'value' },
-    { type: 'attribute', name: 'help-text', value: 'help-text' }
-  ]),
-  render: (args: any) => {
-    return html`<div class="w-[250px] h-[500px]">${generateTemplate({ args })}</div> `;
-  }
-};
-
-/**
  * `sd-textarea` is fully accessibile via keyboard.
  */
 
@@ -467,6 +467,7 @@ export const Combination = generateScreenshotStory([
   StyleOnValid,
   Validation,
   setCustomValidity,
+  ResponsiveHeight,
   Slots,
   Parts,
   Mouseless

--- a/packages/components/src/components/textarea/textarea.test.stories.ts
+++ b/packages/components/src/components/textarea/textarea.test.stories.ts
@@ -346,7 +346,7 @@ export const ResponsiveHeight = {
     { type: 'attribute', name: 'help-text', value: 'help-text' }
   ]),
   render: (args: any) => {
-    return html`<div class="w-[250px] h-[500px]">${generateTemplate({ args })}</div> `;
+    return html`<div class="w-[250px] h-[300px]">${generateTemplate({ args })}</div> `;
   }
 };
 

--- a/packages/components/src/components/textarea/textarea.ts
+++ b/packages/components/src/components/textarea/textarea.ts
@@ -333,7 +333,7 @@ export default class SdTextarea extends SolidElement implements SolidFormControl
     }[this.size];
 
     return html`
-      <div part="form-control" class="text-left">
+      <div part="form-control" class="flex flex-col h-full text-left">
         <label
           part="form-control-label"
           id="label"
@@ -344,7 +344,7 @@ export default class SdTextarea extends SolidElement implements SolidFormControl
           <slot name="label">${this.label}</slot>
         </label>
 
-        <div part="form-control-input" class=${cx('relative w-full', this.disabled && 'cursor-not-allowed')}>
+        <div part="form-control-input" class=${cx('relative h-full w-full', this.disabled && 'cursor-not-allowed')}>
           <div
             part="border"
             class=${cx(
@@ -364,7 +364,7 @@ export default class SdTextarea extends SolidElement implements SolidFormControl
           <div
             part="base"
             class=${cx(
-              'textarea px-4 flex items-top rounded-default group',
+              'textarea h-full px-4 flex items-top rounded-default group',
               {
                 sm: 'textarea-sm py-1',
                 md: 'textarea-md py-1',
@@ -450,7 +450,7 @@ export default class SdTextarea extends SolidElement implements SolidFormControl
     SolidElement.styles,
     css`
       :host {
-        @apply block;
+        @apply block h-full;
       }
 
       :host([required]) #label::after {


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
<!-- *PR notes: Please describe the changes in this PR.* -->
The textarea now takes the full height of it's container. Closes #719.
## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [x] relevant tickets are linked
