### PR TITLE
feat: ✨ add vertical variant to sd-copyright

### DIFF
--- a/packages/components/src/styles/copyright/copyright.css
+++ b/packages/components/src/styles/copyright/copyright.css
@@ -7,7 +7,7 @@
     text-shadow: 0 1px 3px #515151bf;
   }
 
-  &--variant {
+  &--orientation {
     &-vertical {
       &::after {
         @apply pt-2 pb-0 pr-1 pl-0 w-max;

--- a/packages/components/src/styles/copyright/copyright.css
+++ b/packages/components/src/styles/copyright/copyright.css
@@ -6,4 +6,14 @@
     content: var(--copyright);
     text-shadow: 0 1px 3px #515151bf;
   }
+
+  &--variant {
+    &-vertical {
+      &::after {
+        @apply pl-2;
+        writing-mode: vertical-rl;
+        transform: rotate(180deg);
+      }
+    }
+  }
 }

--- a/packages/components/src/styles/copyright/copyright.css
+++ b/packages/components/src/styles/copyright/copyright.css
@@ -12,6 +12,7 @@
       &::after {
         @apply pt-2 pb-0 pr-1 pl-0 w-max;
         writing-mode: vertical-rl;
+        text-orientation: sideways-right;
         transform: rotate(180deg);
       }
     }

--- a/packages/components/src/styles/copyright/copyright.css
+++ b/packages/components/src/styles/copyright/copyright.css
@@ -10,7 +10,7 @@
   &--variant {
     &-vertical {
       &::after {
-        @apply pl-2;
+        @apply pt-2 pb-0 pr-1 pl-0 w-max;
         writing-mode: vertical-rl;
         transform: rotate(180deg);
       }

--- a/packages/components/src/styles/copyright/copyright.declaration.ts
+++ b/packages/components/src/styles/copyright/copyright.declaration.ts
@@ -9,7 +9,7 @@ export default {
     {
       name: 'sd-copyright--orientation-...',
       options: ['vertical'],
-      description: 'The copyrights vertical orientation.'
+      description: 'The copyrights orientation.'
     }
   ]
 } satisfies Style;

--- a/packages/components/src/styles/copyright/copyright.declaration.ts
+++ b/packages/components/src/styles/copyright/copyright.declaration.ts
@@ -7,9 +7,9 @@ export default {
   since: '2.5.0',
   attributes: [
     {
-      name: 'sd-copyright--variant-...',
+      name: 'sd-copyright--orientation-...',
       options: ['vertical'],
-      description: 'The copyrights vertical variant.'
+      description: 'The copyrights vertical orientation.'
     }
   ]
 } satisfies Style;

--- a/packages/components/src/styles/copyright/copyright.declaration.ts
+++ b/packages/components/src/styles/copyright/copyright.declaration.ts
@@ -5,5 +5,11 @@ export default {
   summary: 'Generates basic styles for copyright elements.',
   status: 'stable',
   since: '2.5.0',
-  attributes: []
+  attributes: [
+    {
+      name: 'sd-copyright--variant-...',
+      options: ['vertical'],
+      description: 'The copyrights vertical variant.'
+    }
+  ]
 } satisfies Style;

--- a/packages/components/src/styles/copyright/copyright.stories.ts
+++ b/packages/components/src/styles/copyright/copyright.stories.ts
@@ -1,4 +1,5 @@
 import '../../solid-components';
+import { html } from 'lit-html';
 import { storybookDefaults, storybookHelpers, storybookTemplate } from '../../../scripts/storybook/helper';
 
 const { argTypes, parameters } = storybookDefaults('sd-copyright');
@@ -46,4 +47,34 @@ export const Default = {
       args
     });
   }
+};
+
+/**
+ * Use the `&--variant-*` classes for alternative appearances:
+ * - `horizontal` is the default copyright variant
+ * - `vertical`: use the class `sd-copyright--variant-vertical`
+ */
+
+export const Variants = {
+  render: () =>
+    html`<div class="grid grid-cols-2 gap-4">
+      <div class="sd-copyright max-w-xl" style="--copyright: '© 2024 Solid Design System';">
+        <img
+          src="./placeholders/images/generic.jpg"
+          alt="A generic placeholder jpg"
+          class="aspect-video object-cover"
+        />
+      </div>
+
+      <div
+        class="sd-copyright sd-copyright--variant-vertical max-w-xl"
+        style="--copyright: '© 2024 Solid Design System';"
+      >
+        <img
+          src="./placeholders/images/generic.jpg"
+          alt="A generic placeholder jpg"
+          class="aspect-video object-cover"
+        />
+      </div>
+    </div>`
 };

--- a/packages/components/src/styles/copyright/copyright.stories.ts
+++ b/packages/components/src/styles/copyright/copyright.stories.ts
@@ -50,9 +50,9 @@ export const Default = {
 };
 
 /**
- * Use the `&--variant-*` classes for alternative appearances:
- * - `horizontal` is the default copyright variant
- * - `vertical`: use the class `sd-copyright--variant-vertical`
+ * Use the `&--orientation-*` classes for alternative appearances:
+ * - `horizontal` is the default copyright orientation
+ * - `vertical`: use the class `sd-copyright--orientation-vertical`
  */
 
 export const Variants = {
@@ -67,7 +67,7 @@ export const Variants = {
       </div>
 
       <div
-        class="sd-copyright sd-copyright--variant-vertical max-w-xl"
+        class="sd-copyright sd-copyright--orientation-vertical max-w-xl"
         style="--copyright: '© 2024 Solid Design System';"
       >
         <img


### PR DESCRIPTION
## Description:
Created now a vertical variant for sd-copyright and marked horizontal as default.
Closes https://github.com/solid-design-system/solid/issues/1319.

## Definition of Reviewable:
- [x] relevant tickets are linked
