### PR TITLE
docs: align styles and templates with design docs [skip chromatic]

### DIFF
--- a/packages/components/src/styles/chip/chip.stories.ts
+++ b/packages/components/src/styles/chip/chip.stories.ts
@@ -37,16 +37,16 @@ export const Default = {
   }
 };
 /**
- * Use `sd-chip` modifiers for alternative appearances:
- * - `--primary-200` (default)
- * - `--primary-300`
- * - `--primary-500`
- * - `--white`
+ * Use the `sd-chip` classes for alternative appearances:
+ * - primary-200 is the default background color
+ * - `sd-chip--primary-300`
+ * - `sd-chip--primary-500`
+ * - `sd-chip--white`
  */
 export const Variants = {
   render: () =>
     html` <div class="flex gap-12 bg-neutral-100 p-8">
-      <div class="sd-chip sd-chip--primary-200">primary-200</div>
+      <div class="sd-chip">primary-200</div>
       <div class="sd-chip sd-chip--primary-300">primary-300</div>
       <div class="sd-chip sd-chip--primary-500">primary-500</div>
       <div class="sd-chip sd-chip--white">white</div>

--- a/packages/components/src/styles/container/container.stories.ts
+++ b/packages/components/src/styles/container/container.stories.ts
@@ -36,12 +36,12 @@ export const Default = {
 };
 
 /**
- * Use the `&--variant-*` classes for alternative appearances:
- *- `neutral-100` (default): use the class `sd-container--variant-neutral-100`
- *- `primary-100`: use the class `sd-container--variant-primary-100`
- *- `primary`: use the class `sd-container--variant-primary`
- *- `border-neutral-400`: use the class `sd-container--border-neutral-400`
- *- `white`: use the class `sd-container--variant-white`
+ * Use the `sd-container` classes for alternative appearances:
+ * - `sd-container--variant-neutral-100` (default)
+ * - `sd-container--variant-primary-100`
+ * - `sd-container--variant-primary`
+ * - `sd-container--variant-border-neutral-400`
+ * - `sd-container--variant-white`
  */
 
 export const Variants = {
@@ -70,7 +70,7 @@ export const Variants = {
 };
 
 /**
- * Use the `&--padding-sm` class to adapt the container to smaller component widths.
+ * Use the `sd-container--padding-sm` class to adapt the container to smaller component widths.
  */
 
 export const Padding = {
@@ -92,11 +92,14 @@ export const CustomPadding = {
 };
 
 /**
- * You can add a triangle indentation to the container using the `&--triangle-*` appended with one of the following positions 'top', 'right', 'bottom', 'left' (e.g. sd-container--triangle-top).
+ * Use the `sd-container` classes to add a triangle indentation to the container:
  *
- * - A triangle can be shown to draw attention.
- * - Triangle position can be `top`, `bottom`, `left` or `right`.
- * - Default background option is white and can be overridden if desired.
+ * - `sd-container--triangle-top`
+ * - `sd-container--triangle-right`
+ * - `sd-container--triangle-bottom`
+ * - `sd-container--triangle-left`
+ *
+ * __Hint:__ Default background option is white and can be overridden if desired.
  */
 
 export const TrianglePosition = {
@@ -121,12 +124,12 @@ export const TrianglePosition = {
 };
 
 /**
- * For the `sd-container--variant-border-neutral-400`, use the `&--triangle-*-border` set of classes to create a triangle with a border:
+ * Use the `sd-container` classes to create a triangle with a border when using the variant `sd-container--variant-border-neutral-400`:
  *
- * - `triangle-top-border`
- * - `triangle-right-border`
- * - `triangle-bottom-border`
- * - `triangle-left-border`
+ * - `sd-container--triangle-top-border`
+ * - `sd-container--triangle-right-border`
+ * - `sd-container--triangle-bottom-border`
+ * - `sd-container--triangle-left-border`
  */
 
 export const TriangleBorder = {
@@ -151,7 +154,7 @@ export const TriangleBorder = {
 };
 
 /**
- * Use the CSS property `--triangle-background` to set the triangle cut-out color.
+ * Use the `--triangle-background` CSS property to set the triangle cut-out color.
  */
 
 export const TriangleColor = {

--- a/packages/components/src/styles/copyright/copyright.stories.ts
+++ b/packages/components/src/styles/copyright/copyright.stories.ts
@@ -7,6 +7,12 @@ const { generateTemplate } = storybookTemplate('sd-copyright');
 
 /**
  * Used to be displayed at the bottom of an image for example.
+ *
+ * Use the `--copyright` CSS property and the class `sd-copyright` in the parent of any element to set a copyright text.
+ *
+ * ** Related template:**
+ * - [Media with Copyright](?path=/docs/templates-media--docs#copyright)
+ * - [Video with Copyright](?path=/docs/templates-video--docs#video%20element%20with%20copyright)
  */
 export default {
   title: 'Styles/sd-copyright',

--- a/packages/components/src/styles/display/display.stories.ts
+++ b/packages/components/src/styles/display/display.stories.ts
@@ -38,11 +38,10 @@ export const Default = {
 };
 
 /**
- * Use the `&--size-*` classes for alternative appearances.
-
- * - `sd-display--size-4xl`: 4xl can be used as an alternative
- * - `sd-display--size-3xl`: 3xl can be used as an alternative
- * - xl is the default display size
+ * Use the `sd-display` classes for alternative appearances:
+ * - `sd-display--size-4xl`
+ * - `sd-display--size-3xl`
+ * - xl is the default size
  */
 
 export const Size = {
@@ -56,7 +55,7 @@ export const Size = {
 };
 
 /**
- * Use the `&--inverted` class when displayed on primary background.
+ * Use the `sd-display--inverted` class when displayed on primary background.
  */
 
 export const Inverted = {

--- a/packages/components/src/styles/flag/flag.stories.ts
+++ b/packages/components/src/styles/flag/flag.stories.ts
@@ -38,11 +38,11 @@ export const Default = {
 };
 
 /**
- * Use `sd-flag` modifiers for alternative appearances:
- * - `--neutral-200` (default)
- * - `--neutral-300`
- * - `--neutral-500`
- * - `--white`
+ * Use the `sd-flag` classes for alternative appearances:
+ * - `sd-flag--neutral-200` (default)
+ * - `sd-flag--neutral-300`
+ * - `sd-flag--neutral-500`
+ * - `sd-flag--white`
  */
 
 export const Variants = {

--- a/packages/components/src/styles/footnotes/footnotes.stories.ts
+++ b/packages/components/src/styles/footnotes/footnotes.stories.ts
@@ -80,7 +80,7 @@ export const Variants = {
 };
 
 /**
- * Use the `&--inverted` class when displayed on primary background.
+ * Use the `sd-footnotes--inverted` class when displayed on primary background.
  */
 
 export const Inverted = {

--- a/packages/components/src/styles/headline/headline.stories.ts
+++ b/packages/components/src/styles/headline/headline.stories.ts
@@ -48,9 +48,9 @@ export const Default = {
 };
 
 /**
- * Use the `&--size-*` classes for alternative appearances.
+ * Use the `sd-headline` classes for alternative appearances:
  *
- * - `sd-headline--size-4xl` (default)
+ * - 4xl is the default size
  * - `sd-headline--size-3xl`
  * - `sd-headline--size-xl`
  * - `sd-headline--size-lg`
@@ -69,7 +69,7 @@ export const Sizes = {
 };
 
 /**
- * Use the `&--inverted` class when displayed on primary background.
+ * Use the `sd-headline--inverted` class when displayed on primary background.
  */
 export const Inverted = {
   render: () =>
@@ -79,7 +79,7 @@ export const Inverted = {
 };
 
 /**
- * Use the `&--inline` class to maintain inline positioning when used together with an icon or other components.
+ * Use the `sd-headline--inline` class to maintain inline positioning when used together with an icon or other components.
  */
 export const Inline = {
   render: () => html`

--- a/packages/components/src/styles/hidden-links/hidden-links.stories.ts
+++ b/packages/components/src/styles/hidden-links/hidden-links.stories.ts
@@ -13,7 +13,7 @@ const html = String.raw;
  * Used to show links only for keyboard users.
  *
  * **Related components**:
- * - [Dropdown with Navigation Items](?path=/docs/components-navigation-item--docs)
+ * - [Dropdown with Navigation Items](?path=/docs/templates-dropdown--docs#dropdown-with-navigation-items)
  */
 
 export default {
@@ -56,8 +56,7 @@ export const Default = {
 /**
  * Stack multiple `sd-hidden-links` by adding multiple of them to the same parent.
  *
- * **Hint:**
- * Recommended for 2 or more links.
+ * __Hint:__ Recommended for maximum of 3 hidden links.
  */
 export const StackLinks = {
   render: () =>
@@ -69,10 +68,9 @@ export const StackLinks = {
 };
 
 /**
- * Use the `&--multiple` class to show mutiple `sd-navigation-item` elements.
+ * Use the `sd-hidden-links--multiple` class to show multiple `sd-navigation-item` elements.
  *
- * **Hint:**
- * Recommended for 2 or more links.
+ * __Hint:__ Recommended for more than 3 links.
  */
 export const MultipleLinks = {
   render: () =>
@@ -87,7 +85,7 @@ export const MultipleLinks = {
 };
 
 /**
- * Use the `--sd-hidden-links-title` CSS variable to set a title for multiple links.
+ * Use the `--sd-hidden-links-title` CSS property to set a title for multiple links.
  *
  * German and English are set by default in regard of the document's or elements `lang` attribute.
  */
@@ -183,7 +181,7 @@ export const SurroundingContent = {
 };
 
 /**
- * Use the `&--debug` class to always show the links for debugging purposes.
+ * Use the `sd-hidden-links--debug` class to always show the links for debugging purposes.
  */
 export const Debug = {
   parameters: {

--- a/packages/components/src/styles/interactive/interactive.stories.ts
+++ b/packages/components/src/styles/interactive/interactive.stories.ts
@@ -42,7 +42,7 @@ export const Default = {
 };
 
 /**
- * Use the `&--inverted` class when displayed on primary background.
+ * Use the `sd-interactive--inverted` class when displayed on primary background.
  */
 
 export const Inverted = {
@@ -54,7 +54,7 @@ export const Inverted = {
 };
 
 /**
- * Use the `&--disabled` class to disable an interactive element.
+ * Use the `sd-interactive--disabled` class to disable an interactive element.
  *
  * This works as well when setting an `disabled` attribute on the element.
  */
@@ -64,7 +64,7 @@ export const Disabled = {
 };
 
 /**
- * Use the `&--reset` class to reset the default browser styles of e. g. a button.
+ * Use the `sd-interactive--reset` class to reset the default browser styles of e. g. a button.
  */
 
 export const Reset = {

--- a/packages/components/src/styles/leadtext/leadtext.stories.ts
+++ b/packages/components/src/styles/leadtext/leadtext.stories.ts
@@ -43,9 +43,9 @@ export const Default = {
 };
 
 /**
- * Use the `&--size-lg` class for alternative appearances:
+ * Use the `sd-leadtext` classes for alternative appearances:
  * -  xl is the default leadtext size
- * - `sd-leadtext--size-lg`: lg can be used as an alternative
+ * - `sd-leadtext--size-lg`
  */
 
 export const Size = {
@@ -66,7 +66,7 @@ export const Size = {
 };
 
 /**
- * Use the `&--inverted` class when displayed on primary background.
+ * Use the `sd-leadtext--inverted` class when displayed on primary background.
  */
 
 export const Inverted = {

--- a/packages/components/src/styles/list/list.stories.ts
+++ b/packages/components/src/styles/list/list.stories.ts
@@ -12,8 +12,8 @@ const { generateTemplate } = storybookTemplate('sd-list');
  * Text lists can be numbered, have bullet points, or be supplemented by content symbols. Text can be bolded or linked.
  *
  * **Related templates**:
- * - [List with Bolded Text](?path=/docs/templates-list-with-bolded-text--docs)
- * - [Link list](?path=/docs/templates-link-list--docs)
+ * - [List](?path=/docs/templates-list--docs)
+ * - [Link list](?path=/docs/templates-link--docs&globals=backgrounds.value:transparent#link-list)
  */
 
 export default {
@@ -53,11 +53,11 @@ export const Default = {
 };
 
 /**
- * Use `sd-list` modifiers for alternative appearances.
+ * Use `sd-list` modifiers for alternative appearances:
  *
- * - `Unordered list group`: use the class `sd-list` when there is no specific sequence or order to the items
- * - `Ordered list group`: use the class `sd-list` when the items have a specific sequence or count
- * - `Icon list group`: used when a content icon is needed to illustrate the text content
+ * - `ul` standard html list element to create an unnumbered list
+ * - `ol` standard html list element to create a numbered list
+ * - `sd-list--icon` class to create an icon list
  */
 
 export const Variants = {
@@ -156,7 +156,7 @@ export const Levels = {
 };
 
 /**
- * Use the `&--horizontal` class to set the axis of the list displaying content icons to horizontal.
+ * Use the `sd-list--horizontal` class to set the axis of the list displaying content icons to horizontal.
  */
 export const Orientation = {
   render: () =>
@@ -193,7 +193,7 @@ export const Orientation = {
 };
 
 /**
- * Use the `&--inverted` class when displayed on primary background.
+ * Use the `sd-list--inverted` class when displayed on primary background.
  */
 export const Inverted = {
   render: () =>

--- a/packages/components/src/styles/media/media.stories.ts
+++ b/packages/components/src/styles/media/media.stories.ts
@@ -9,7 +9,7 @@ const { generateTemplate } = storybookTemplate('sd-media');
 /**
  * Used to display an image or a video preview.
  *
- *  * **Related templates**:
+ * **Related templates**:
  * - [Media](?path=/docs/templates-media--docs)
  */
 export default {
@@ -44,7 +44,7 @@ export const Default = {
 };
 
 /**
- * Use the `&--inverted` class when displayed on primary background if description is added.
+ * Use the `sd-media--inverted` class when displayed on primary background if description is added.
  */
 
 export const Inverted = {

--- a/packages/components/src/styles/meta/meta.stories.ts
+++ b/packages/components/src/styles/meta/meta.stories.ts
@@ -35,25 +35,25 @@ export const Default = {
 };
 
 /**
- * Use `sd-meta` modifiers for alternative appearances.
+ * Use the `sd-meta` classes for alternative appearances:
  *
- * - Black is the default
- * - `sd-meta--light`: Neutral-700 can be used to deemphasize text content
+ * - Black is the default color
+ * - `sd-meta--light`: Neutral-700
  */
 
 export const Variants = {
   render: () =>
     html`<div class="flex flex-row gap-12">
-      <span class="sd-meta">Black</span>
-      <span class="sd-meta sd-meta--light">Neutral-700</span>
+      <span class="sd-meta">Default</span>
+      <span class="sd-meta sd-meta--light">Light</span>
     </div>`
 };
 
 /**
- * Use `&--size-*` class for alternative appearances.
+ * Use `sd-meta` classes for alternative appearances:
  *
  * - lg is the default size
- * - `sd-meta--size-sm`: sm can be used as an alternative in tight spaces
+ * - `sd-meta--size-sm`
  */
 
 export const Size = {
@@ -65,21 +65,21 @@ export const Size = {
 };
 
 /**
- * Use the `&--inverted` class when displayed on primary background.
+ * Use the `sd-meta--inverted` class when displayed on primary background.
  *
  * - White is the default
- * - `sd-meta--light`: Primary-400 can be used to deemphasize text content
+ * - `sd-meta--light`: Primary-400
  */
 export const Inverted = {
   render: () =>
     html` <div class="p-4 bg-primary flex flex-row gap-12">
-      <span class="sd-meta sd-meta--inverted">White</span>
-      <span class="sd-meta sd-meta--inverted sd-meta--light">Primary-400</span>
+      <span class="sd-meta sd-meta--inverted">Default</span>
+      <span class="sd-meta sd-meta--inverted sd-meta--light">Light</span>
     </div>`
 };
 
 /**
- * Use the `&--pipe` class to separate meta information with a pipe.
+ * Use the `sd-meta--pipe` class to separate meta information with a pipe.
  */
 export const Pipe = {
   render: () =>

--- a/packages/components/src/styles/paragraph/paragraph.stories.ts
+++ b/packages/components/src/styles/paragraph/paragraph.stories.ts
@@ -41,10 +41,10 @@ export const Default = {
 };
 
 /**
- * Use the `&--size-*`classes for alternative appearances.
+ * Use the `sd-paragraph` classes for alternative appearances:
  *
- * - lg is the default paragraph size
- * - `sd-paragraph--size-sm`: sm can be used as an alternative
+ * - lg is the default size
+ * - `sd-paragraph--size-sm`
  */
 
 export const Size = {
@@ -65,7 +65,7 @@ export const Size = {
 };
 
 /**
- * Use the `&--inverted` class when displayed on primary background.
+ * Use the `sd-paragraph--inverted` class when displayed on primary background.
  */
 
 export const Inverted = {

--- a/packages/components/src/styles/prose/prose.stories.ts
+++ b/packages/components/src/styles/prose/prose.stories.ts
@@ -48,7 +48,7 @@ export const Default = {
 };
 
 /**
- * Use the `sd-prose` to set a style for a group of elements.
+ * Use the `sd-prose` to set a style for a group of elements:
  *
  * - `<h1>`: H1, hidden in cms-modules to make sure H1 is only used once on a page
  * - `<h2>, <h3>, <h4> and <h5>`: H2, H3, H4 and H5
@@ -166,7 +166,7 @@ export const StylingOptions = {
 };
 
 /**
- * Use the `&--full-width` class to make the prose full width.
+ * Use the `sd-prose--full-width` class to make the prose full width.
  */
 export const FullWidth = {
   render: () =>
@@ -191,7 +191,7 @@ export const FullWidth = {
 };
 
 /**
- * Use the `&--inverted` class when displayed on primary background.
+ * Use the `sd-prose--inverted` class when displayed on primary background.
  */
 export const Inverted = {
   render: () => html`


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
<!-- *PR notes: Please describe the changes in this PR.* -->
- In the side menu in Storybook 1st show simple component (eg. accordion) and after the group (eg.accordion-group)
- In the side menu in Storybook all templates should have "resumed names" (eg. Badge) instead of (eg. Button with Badge)
- 1st show Related Components and 2nd show Related Templates
- On the 1st sample we use the component name when possible (eg. Button) instead of (Default)
- In code the 1st sample has slots vs in Figma slots are only shown if no interactions is required. When interaction is required we use the slots in the next samples.
- Use the "open" attribute, Use "summary" to ...
- When displaying options and variants, 1st line of copy has ":" at the end (eg. Use the ”variant” attribute to set the button’s variant:) and the bullet list never has a "." at the end.
- The samples should help empasize what is being shown. If we are talking about "Inverted" components shown should have "Inverted" in the text
- If variants or options are shown we should use bullet list bellow sample
- Always add (default) in front of the default variant/size/etc. (e.g., lg (default)).
- If a bullet list is shown, use a colon in the sentence (e.g., "Use the size attribute to change a button’s size: ").
- In bullet lists, do not use any kind of punctuation marks at the end of the sentence (e.g., lg (default)).
- Ensure you add a period at the end of all sentences.
- Always use the attribute of classes' nomenclature (e.g., instead of "large", use lg).
- Template links in components must point to the mentioned section within the template. If the template have the name of the component link the full template.
- The naming of related templates must be Component Only or if pointing to a specific section Component - Component (eg: in sd-select link it to the template select , in sd-tooltip link to the section Select with Tooltip ).
- In docs, the related components and related templates lists must be ordered by relevance.

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [x] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
