### PR TITLE
docs: add disclaimer to address Storybook bug (wrong type in sd-carousel variant) 

### DIFF
--- a/packages/components/src/components/carousel/carousel.stories.ts
+++ b/packages/components/src/components/carousel/carousel.stories.ts
@@ -20,6 +20,8 @@ const { generateTemplate } = storybookTemplate('sd-carousel');
  *
  * **Related templates**:
  * - [Carousel](?path=/docs/templates-carousel--docs)
+ *
+ * **Disclaimer** : We're facing an issue with the variant controls in the carousel component. It should offer a choice between number and dot variants but is incorrectly shown as a number input. The issue originates from Storybook, not the component.
  */
 
 export default {


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
<!-- *PR notes: Please describe the changes in this PR.* -->
This bug arises due to Storybook interpreting the option name "number" as a type, even though we manually describe the type as a String. Changing the name resolves this issue, but making a breaking change for a Storybook issue is not viable.

![Image](https://github.com/user-attachments/assets/f374a937-dd63-4ef7-9ba9-da93e4d4aa7c)


Since this is not related to the component, I added a disclaimer to inform users of this issue. Closes #1249

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [x] Documentation is created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [x] Stories (features, a11y) are created/updated
- [x] relevant tickets are linked
