### PR TITLE
docs: add a11y warning for sd-notification [skip chromatic]

### DIFF
--- a/packages/components/src/components/notification/notification.stories.ts
+++ b/packages/components/src/components/notification/notification.stories.ts
@@ -11,6 +11,11 @@ const { overrideArgs } = storybookHelpers('sd-notification');
 /**
  * Used to communicate important information or status to the user. Notifications can be displayed inline or as a toast / toast stack.
  *
+ * > **Warning:** Our accessibility audit in 10/2024 found several problems with the `toast()` method. These are mostly related to the
+ * > general concept of toasts, rather than how it is implemented. We will investigate how to improve this in the future. For now,
+ * > we strongly recommend using inline notifications instead of toasts. For further information, please refer to our
+ * > [GitHub issue](https://github.com/solid-design-system/solid/issues/1482).
+ *
  *  **Related templates**:
  * - [Notification](?path=/docs/templates-notification--docs)
  */


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
<!-- *PR notes: Please describe the changes in this PR.* -->

As discussed in our daily, I added some information in the notification.

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [x] Documentation is created/updated