### PR TITLE
docs: remove primary story from templates

### DIFF
--- a/packages/components/.storybook/preview-head.html
+++ b/packages/components/.storybook/preview-head.html
@@ -154,12 +154,10 @@
     const storiesSection = [...document.querySelectorAll('h2')].find(header => header.textContent.trim() === 'Stories');
 
     if (storiesSection && document.title.includes('templates-')) {
-      // gets all the stories before the header
       const previousSiblings = [];
       let sibling = storiesSection.previousElementSibling;
 
       while (sibling) {
-        // collects stories before the header
         if (sibling.classList.contains('sb-anchor')) {
           previousSiblings.push(sibling);
         }

--- a/packages/components/.storybook/preview-head.html
+++ b/packages/components/.storybook/preview-head.html
@@ -132,11 +132,10 @@
   /**
     * Optimize autodocs for templates
     */
-  .sbdocs-title + * + [id^='anchor--templates-'].sb-anchor,
-  h1.sbdocs-title + * + [id^='anchor--templates-'].sb-anchor + h2,
-  [id^='anchor--templates-'].sb-anchor > .sbdocs > .sb-bar,
+  h2#stories,
   h2#stories + [id^='anchor--components-'].sb-anchor,
-  h2#stories + [id^='anchor--styles-'].sb-anchor {
+  h2#stories + [id^='anchor--styles-'].sb-anchor,
+  [id^='anchor--templates-'].sb-anchor > .sbdocs > .sb-bar {
     display: none;
   }
 
@@ -144,3 +143,31 @@
     padding: 0;
   }
 </style>
+<script>
+  /**
+   * Dev note: this script is used to remove the first story generated in the templates. This story is automatically
+   * generated and contains the same id as the second story and this causes issues when adding interactivity to the stories.
+   */
+
+  document.addEventListener('DOMContentLoaded', function () {
+    // find the start of the stories section using the header
+    const storiesSection = [...document.querySelectorAll('h2')].find(header => header.textContent.trim() === 'Stories');
+
+    if (storiesSection && document.title.includes('templates-')) {
+      // gets all the stories before the header
+      const previousSiblings = [];
+      let sibling = storiesSection.previousElementSibling;
+
+      while (sibling) {
+        // collects stories before the header
+        if (sibling.classList.contains('sb-anchor')) {
+          previousSiblings.push(sibling);
+        }
+        sibling = sibling.previousElementSibling;
+      }
+
+      // removes all the previous stories
+      previousSiblings.forEach(story => story.remove());
+    }
+  });
+</script>

--- a/packages/components/scripts/storybook/docs-codepen-enhancer.ts
+++ b/packages/components/scripts/storybook/docs-codepen-enhancer.ts
@@ -44,7 +44,11 @@ export default function docsCodepenEnhancer(code: string, storyContext: StoryCon
           el.style.display = 'block';
           el.style.borderRight = 'none';
         });
-        story.querySelector<HTMLElement>('.docblock-codepen-button:last-of-type')!.style.display = 'none';
+
+        const buttons = story.querySelectorAll<HTMLElement>('.docblock-codepen-button');
+        if (buttons.length > 1) {
+          buttons[buttons.length - 1].style.display = 'none';
+        }
       }
 
       // Finally add the event listener to the button

--- a/packages/components/src/templates/audio.stories.ts
+++ b/packages/components/src/templates/audio.stories.ts
@@ -1,11 +1,6 @@
 import '../solid-components';
 import { html } from 'lit-html';
 
-/**
- * ```
- * ```
- */
-
 export default {
   tags: ['!dev'],
   title: 'Templates/Audio',

--- a/packages/components/src/templates/badge.stories.ts
+++ b/packages/components/src/templates/badge.stories.ts
@@ -1,10 +1,6 @@
 import '../solid-components';
 import { html } from 'lit-html';
 
-/**
- * ```
- * ```
- */
 export default {
   tags: ['!dev'],
   title: 'Templates/Badge',

--- a/packages/components/src/templates/brandshape.stories.ts
+++ b/packages/components/src/templates/brandshape.stories.ts
@@ -1,10 +1,6 @@
 import '../solid-components';
 import { html } from 'lit-html';
 
-/**
- * ```
- * ```
- */
 export default {
   tags: ['!dev'],
   title: 'Templates/Brandshape',

--- a/packages/components/src/templates/button.stories.ts
+++ b/packages/components/src/templates/button.stories.ts
@@ -1,11 +1,6 @@
 import '../solid-components';
 import { html } from 'lit-html';
 
-/**
- * ```
- * ```
- */
-
 export default {
   tags: ['!dev'],
   title: 'Templates/Button',

--- a/packages/components/src/templates/carousel.stories.ts
+++ b/packages/components/src/templates/carousel.stories.ts
@@ -1,10 +1,6 @@
 import '../solid-components';
 import { html } from 'lit-html';
 
-/**
- * ```
- * ```
- */
 export default {
   tags: ['!dev'],
   title: 'Templates/Carousel',

--- a/packages/components/src/templates/checkbox-group.stories.ts
+++ b/packages/components/src/templates/checkbox-group.stories.ts
@@ -1,10 +1,6 @@
 import '../solid-components';
 import { html } from 'lit-html';
 
-/**
- * ```
- * ```
- */
 export default {
   tags: ['!dev'],
   title: 'Templates/Checkbox Group',

--- a/packages/components/src/templates/chip.stories.ts
+++ b/packages/components/src/templates/chip.stories.ts
@@ -1,10 +1,6 @@
 import '../solid-components';
 import { html } from 'lit-html';
 
-/**
- * ```
- * ```
- */
 export default {
   tags: ['!dev'],
   title: 'Templates/Chip',

--- a/packages/components/src/templates/dialog.stories.ts
+++ b/packages/components/src/templates/dialog.stories.ts
@@ -1,10 +1,6 @@
 import '../solid-components';
 import { html } from 'lit-html';
 
-/**
- * ```
- * ```
- */
 export default {
   tags: ['!dev'],
   title: 'Templates/Dialog',

--- a/packages/components/src/templates/drawer.stories.ts
+++ b/packages/components/src/templates/drawer.stories.ts
@@ -1,10 +1,6 @@
 import '../solid-components';
 import { html } from 'lit-html';
 
-/**
- * ```
- * ```
- */
 export default {
   tags: ['!dev'],
   title: 'Templates/Drawer',

--- a/packages/components/src/templates/dropdown.stories.ts
+++ b/packages/components/src/templates/dropdown.stories.ts
@@ -1,10 +1,6 @@
 import '../solid-components';
 import { html } from 'lit-html';
 
-/**
- * ```
- * ```
- */
 export default {
   tags: ['!dev'],
   title: 'Templates/Dropdown',

--- a/packages/components/src/templates/expandable.stories.ts
+++ b/packages/components/src/templates/expandable.stories.ts
@@ -1,10 +1,6 @@
 import '../solid-components';
 import { html } from 'lit-html';
 
-/**
- * ```
- * ```
- */
 export default {
   tags: ['!dev'],
   title: 'Templates/Expandable',

--- a/packages/components/src/templates/flag.stories.ts
+++ b/packages/components/src/templates/flag.stories.ts
@@ -1,10 +1,6 @@
 import '../solid-components';
 import { html } from 'lit-html';
 
-/**
- * ```
- * ```
- */
 export default {
   tags: ['!dev'],
   title: 'Templates/Flag',

--- a/packages/components/src/templates/footnotes.stories.ts
+++ b/packages/components/src/templates/footnotes.stories.ts
@@ -1,10 +1,6 @@
 import '../solid-components';
 import { html } from 'lit-html';
 
-/**
- * ```
- * ```
- */
 export default {
   tags: ['!dev'],
   title: 'Templates/Footnotes',

--- a/packages/components/src/templates/header.stories.ts
+++ b/packages/components/src/templates/header.stories.ts
@@ -1,10 +1,6 @@
 import '../solid-components';
 import { html } from 'lit-html';
 
-/**
- * ```
- * ```
- */
 export default {
   tags: ['!dev'],
   parameters: {

--- a/packages/components/src/templates/input.stories.ts
+++ b/packages/components/src/templates/input.stories.ts
@@ -2,10 +2,6 @@ import '../solid-components';
 import { html } from 'lit-html';
 import type SdInput from '../components/input/input';
 
-/**
- * ```
- * ```
- */
 export default {
   tags: ['!dev'],
   title: 'Templates/Input',

--- a/packages/components/src/templates/interactive.stories.ts
+++ b/packages/components/src/templates/interactive.stories.ts
@@ -1,10 +1,6 @@
 import '../solid-components';
 import { html } from 'lit-html';
 
-/**
- * ```
- * ```
- */
 export default {
   tags: ['!dev'],
   title: 'Templates/Interactive',

--- a/packages/components/src/templates/link.stories.ts
+++ b/packages/components/src/templates/link.stories.ts
@@ -1,10 +1,6 @@
 import '../solid-components';
 import { html } from 'lit-html';
 
-/**
- * ```
- * ```
- */
 export default {
   tags: ['!dev'],
   title: 'Templates/Link',

--- a/packages/components/src/templates/list.stories.ts
+++ b/packages/components/src/templates/list.stories.ts
@@ -1,10 +1,6 @@
 import '../solid-components';
 import { html } from 'lit-html';
 
-/**
- * ```
- * ```
- */
 export default {
   tags: ['!dev'],
   title: 'Templates/List',

--- a/packages/components/src/templates/map-marker.stories.ts
+++ b/packages/components/src/templates/map-marker.stories.ts
@@ -1,10 +1,6 @@
 import '../solid-components';
 import { html } from 'lit-html';
 
-/**
- * ```
- * ```
- */
 export default {
   tags: ['!dev'],
   title: 'Templates/Map Marker',

--- a/packages/components/src/templates/media.stories.ts
+++ b/packages/components/src/templates/media.stories.ts
@@ -1,10 +1,6 @@
 import '../solid-components';
 import { html } from 'lit-html';
 
-/**
- * ```
- * ```
- */
 export default {
   title: 'Templates/Media',
   tags: ['!dev'],

--- a/packages/components/src/templates/notification.stories.ts
+++ b/packages/components/src/templates/notification.stories.ts
@@ -3,10 +3,6 @@
 import '../solid-components';
 import { html } from 'lit';
 
-/**
- * ```
- * ```
- */
 export default {
   title: 'Templates/Notification',
   tags: ['!dev'],

--- a/packages/components/src/templates/quickfact.stories.ts
+++ b/packages/components/src/templates/quickfact.stories.ts
@@ -1,10 +1,6 @@
 import '../solid-components';
 import { html } from 'lit-html';
 
-/**
- * ```
- * ```
- */
 export default {
   tags: ['!dev'],
   parameters: {

--- a/packages/components/src/templates/quote.stories.ts
+++ b/packages/components/src/templates/quote.stories.ts
@@ -1,10 +1,6 @@
 import '../solid-components';
 import { html } from 'lit-html';
 
-/**
- * ```
- * ```
- */
 export default {
   tags: ['!dev'],
   title: 'Templates/Quote',

--- a/packages/components/src/templates/select.stories.ts
+++ b/packages/components/src/templates/select.stories.ts
@@ -1,10 +1,6 @@
 import '../solid-components';
 import { html } from 'lit-html';
 
-/**
- * ```
- * ```
- */
 export default {
   tags: ['!dev'],
   title: 'Templates/Select',

--- a/packages/components/src/templates/step-group.stories.ts
+++ b/packages/components/src/templates/step-group.stories.ts
@@ -1,10 +1,6 @@
 import '../solid-components';
 import { html } from 'lit-html';
 
-/**
- * ```
- * ```
- */
 export default {
   tags: ['!dev'],
   title: 'Templates/Step Group',

--- a/packages/components/src/templates/supernumber.stories.ts
+++ b/packages/components/src/templates/supernumber.stories.ts
@@ -1,10 +1,6 @@
 import '../solid-components';
 import { html } from 'lit-html';
 
-/**
- * ```
- * ```
- */
 export default {
   tags: ['!dev'],
   title: 'Templates/Supernumber',

--- a/packages/components/src/templates/tab.stories.ts
+++ b/packages/components/src/templates/tab.stories.ts
@@ -1,10 +1,6 @@
 import '../solid-components';
 import { html } from 'lit-html';
 
-/**
- * ```
- * ```
- */
 export default {
   tags: ['!dev'],
   title: 'Templates/Tab',

--- a/packages/components/src/templates/tag.stories.ts
+++ b/packages/components/src/templates/tag.stories.ts
@@ -1,10 +1,6 @@
 import '../solid-components';
 import { html } from 'lit-html';
 
-/**
- * ```
- * ```
- */
 export default {
   tags: ['!dev'],
   title: 'Templates/Tag',

--- a/packages/components/src/templates/teaser-media.stories.ts
+++ b/packages/components/src/templates/teaser-media.stories.ts
@@ -1,10 +1,6 @@
 import '../solid-components';
 import { html } from 'lit-html';
 
-/**
- * ```
- * ```
- */
 export default {
   tags: ['!dev'],
   title: 'Templates/Teaser Media',

--- a/packages/components/src/templates/teaser.stories.ts
+++ b/packages/components/src/templates/teaser.stories.ts
@@ -1,10 +1,6 @@
 import '../solid-components';
 import { html } from 'lit-html';
 
-/**
- * ```
- * ```
- */
 export default {
   tags: ['!dev'],
   title: 'Templates/Teaser',

--- a/packages/components/src/templates/video-with-description-and-copyright.stories.ts
+++ b/packages/components/src/templates/video-with-description-and-copyright.stories.ts
@@ -1,10 +1,6 @@
 import '../solid-components';
 import { html } from 'lit-html';
 
-/**
- * ```
- * ```
- */
 export default {
   tags: ['!dev'],
   title: 'Templates/Video',


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
This PR removes the auto generated first story in the templates section. Because this story mimics the following story's id, it creates issues when adding interactivity to the stories. 

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
