### PR TITLE
docs: add a11y watchlist page to Storybook [skip chromatic]

### DIFF
--- a/packages/components/src/docs/General/11-FAQ.mdx
+++ b/packages/components/src/docs/General/11-FAQ.mdx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/blocks';
-import '../../styles/headline/headline.css';
 import 'https://solid-design-system.fe.union-investment.de/x.x.x/components/es/accordion.js';
 import 'https://solid-design-system.fe.union-investment.de/x.x.x/components/es/accordion-group.js';
 

--- a/packages/components/src/docs/General/15-A11y Watchlist.mdx
+++ b/packages/components/src/docs/General/15-A11y Watchlist.mdx
@@ -8,15 +8,15 @@ import 'https://solid-design-system.fe.union-investment.de/x.x.x/components/es/a
     <p class="sd-prose">
       Following our accessibility audit, we identified potential risks in several components. To help determine whether we need to adjust functionality, make design compromises, or even remove certain components from the library, we've outlined key details for each one. The components are categorized into two sections:
       <ol>
-        <li>Inspect - This section includes components with identified accessibility concerns that require further analysis.</li>
-        <li>Refined - This section lists components where potential solutions have been proposed, ready for discussion with our stakeholders.</li>
+        <li>**Inspect** - This section includes components with identified accessibility concerns that require further analysis.</li>
+        <li>**Refined** - This section lists components where potential solutions have been proposed, ready for discussion with our stakeholders.</li>
       </ol>
       Our aim is to address these issues thoughtfully, collaboratively and transparent to enhance accessibility in our design system.
     </p>
-  <h2 class="sd-headline sd-headline--size-3xl pt-6 pb-2 mb-4">Inspect</h2>
+  <h3 class="sd-headline sd-headline--size-3xl pt-6 pb-2 mb-4">Inspect</h3>
     <sd-accordion-group class="mb-4">
       <sd-accordion>
-        <h3 class="text-base" slot="summary">sd-notification</h3>
+        <span class="text-base" slot="summary">sd-notification</span>
         <span class="sd-prose">
           <h4 class="sd-headline sd-headline--size-lg">Problem(s)</h4>
             <ul>
@@ -31,18 +31,18 @@ import 'https://solid-design-system.fe.union-investment.de/x.x.x/components/es/a
             </ol>
           <h4 class="sd-headline sd-headline--size-lg">Links</h4>
             <ul>
-              <li><a href="?path=/docs/components-sd-notification--docs">sd-notification Documentation</a></li>
+              <li>[sd-notification Documentation](?path=/docs/components-sd-notification--docs)</li>
               <li><a href="https://www.notion.so/matuzo/sd-notification-10ef3f6e1bc08069a42fff79906f5254" target="_blank">sd-notification a11y findings</a></li>
             </ul>
         </span>
       </sd-accordion>
     </sd-accordion-group>
-    <h2 class="sd-headline sd-headline--size-3xl pt-6 pb-2 mb-4">Refined</h2>
+    <h3 class="sd-headline sd-headline--size-3xl pt-6 pb-2 mb-4">Refined</h3>
     <sd-accordion-group class="mb-4">
       <sd-accordion>
-        <h3 class="text-base" slot="summary">
+        <span class="text-base" slot="summary">
           sd-TBA
-        </h3>
+        </span>
         <span class="sd-prose">
           <h4 class="sd-headline sd-headline--size-lg">Problem(s)</h4>
           <ul>
@@ -58,9 +58,7 @@ import 'https://solid-design-system.fe.union-investment.de/x.x.x/components/es/a
           </ol>
           <h4 class="sd-headline sd-headline--size-lg">Links</h4>
           <ul>
-            <li>
-              <a href="?path=/docs/components-sd-[REPLACE]--docs">sd-[REPLACE] Documentation</a>
-            </li>
+            <li>[sd-[REPLACE] Documentation](?path=/docs/components-sd-[REPLACE]--docs)</li>
             <li><a href="https://www.notion.so/matuzo/[REPLACE]" target="_blank">sd-[REPLACE] a11y findings</a></li>
           </ul>
         </span>

--- a/packages/components/src/docs/General/15-A11y Watchlist.mdx
+++ b/packages/components/src/docs/General/15-A11y Watchlist.mdx
@@ -11,7 +11,7 @@ import 'https://solid-design-system.fe.union-investment.de/x.x.x/components/es/a
         <li>Inspect - This section includes components with identified accessibility concerns that require further analysis.</li>
         <li>Refined - This section lists components where potential solutions have been proposed, ready for discussion with our stakeholders.</li>
       </ol>
-      Our aim is to address these issues thoughtfully and collaboratively to enhance accessibility in our design system.
+      Our aim is to address these issues thoughtfully, collaboratively and transparent to enhance accessibility in our design system.
     </p>
   <h2 class="sd-headline sd-headline--size-3xl pt-6 pb-2 mb-4">Inspect</h2>
     <sd-accordion-group class="mb-4">

--- a/packages/components/src/docs/General/15-A11y Watchlist.mdx
+++ b/packages/components/src/docs/General/15-A11y Watchlist.mdx
@@ -1,0 +1,70 @@
+import { Meta } from '@storybook/blocks';
+import 'https://solid-design-system.fe.union-investment.de/x.x.x/components/es/accordion.js';
+import 'https://solid-design-system.fe.union-investment.de/x.x.x/components/es/accordion-group.js';
+
+<Meta title="Docs/General/A11y Watchlist" />
+<span class="sb-unstyled">
+  <h1 class="sd-headline mb-4">A11y Watchlist of the Solid Design System</h1>
+    <p class="sd-prose">
+      Following our accessibility audit, we identified potential risks in several components. To help determine whether we need to adjust functionality, make design compromises, or even remove certain components from the library, we've outlined key details for each one. The components are categorized into two sections:
+      <ol>
+        <li>Inspect - This section includes components with identified accessibility concerns that require further analysis.</li>
+        <li>Refined - This section lists components where potential solutions have been proposed, ready for discussion with our stakeholders.</li>
+      </ol>
+      Our aim is to address these issues thoughtfully and collaboratively to enhance accessibility in our design system.
+    </p>
+  <h2 class="sd-headline sd-headline--size-3xl pt-6 pb-2 mb-4">Inspect</h2>
+    <sd-accordion-group class="mb-4">
+      <sd-accordion>
+        <h3 class="text-base" slot="summary">sd-notification</h3>
+        <span class="sd-prose">
+          <h4 class="sd-headline sd-headline--size-lg">Problem(s)</h4>
+            <ul>
+              <li>People who use software to zoom into parts on the screen may miss toast messages.</li>
+              <li>When the page is zoomed in, toasts may obscure large parts of the screen.</li>
+              <li>Keyboard users must tab through the remaining page to close toasts or use other controls within.</li>
+            </ul>
+          <h4 class="sd-headline sd-headline--size-lg">Possible Solution(s)</h4>
+            <ol>
+              <li>Don't use toasted notification, only use inline notifications.</li>
+              <li>Add user info, to prevent adding critical information AND interaction elements to a toasted notification.</li>
+            </ol>
+          <h4 class="sd-headline sd-headline--size-lg">Links</h4>
+            <ul>
+              <li><a href="?path=/docs/components-sd-notification--docs">sd-notification Documentation</a></li>
+              <li><a href="https://www.notion.so/matuzo/sd-notification-10ef3f6e1bc08069a42fff79906f5254" target="_blank">sd-notification a11y findings</a></li>
+            </ul>
+        </span>
+      </sd-accordion>
+    </sd-accordion-group>
+    <h2 class="sd-headline sd-headline--size-3xl pt-6 pb-2 mb-4">Refined</h2>
+    <sd-accordion-group class="mb-4">
+      <sd-accordion>
+        <h3 class="text-base" slot="summary">
+          sd-TBA
+        </h3>
+        <span class="sd-prose">
+          <h4 class="sd-headline sd-headline--size-lg">Problem(s)</h4>
+          <ul>
+            <li>lorem ipsum</li>
+            <li>lorem ipsum</li>
+            <li>lorem ipsum</li>
+          </ul>
+          <h4 class="sd-headline sd-headline--size-lg">Possible Solution(s)</h4>
+          <ol>
+            <li>lorem ipsum</li>
+            <li>lorem ipsum</li>
+            <li>lorem ipsum</li>
+          </ol>
+          <h4 class="sd-headline sd-headline--size-lg">Links</h4>
+          <ul>
+            <li>
+              <a href="?path=/docs/components-sd-[REPLACE]--docs">sd-[REPLACE] Documentation</a>
+            </li>
+            <li><a href="https://www.notion.so/matuzo/[REPLACE]" target="_blank">sd-[REPLACE] a11y findings</a></li>
+          </ul>
+        </span>
+      </sd-accordion>
+    </sd-accordion-group>
+
+</span>


### PR DESCRIPTION
## Description:
- Adds new page to storybook docs in order to provide a basis for decision-making for a11y issues.
- Adds `sd-notification` as first component

closes #1598
## Definition of Reviewable:
- [x] Documentation is created/updated
- [x] relevant tickets are linked
