### PR TITLE
fix: sd-interactive a11y template 

### DIFF
--- a/packages/components/src/templates/interactive.stories.ts
+++ b/packages/components/src/templates/interactive.stories.ts
@@ -26,7 +26,7 @@ export const Examples = {
     <div class="flex flex-col gap-12">
       <button class="sd-interactive sd-interactive--reset">Text</button>
       <button class="sd-interactive sd-interactive--reset">
-        <sd-icon library="global-resources" name="system/picture"></sd-icon>
+        <sd-icon library="global-resources" name="system/picture" label="Icon only button"></sd-icon>
       </button>
       <button class="sd-interactive sd-interactive--reset flex flex-row items-center gap-2">
         <sd-icon library="global-resources" name="system/picture"></sd-icon>


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
Add an accessible name to the icon-only interactive button in the `sd-interactive` template to improve accessibility for users who rely on screen readers.

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
