### PR TITLE
docs: update developer starting guide [skip chromatic]

### DIFF
--- a/DEVELOPER_STARTING_GUIDE.md
+++ b/DEVELOPER_STARTING_GUIDE.md
@@ -24,7 +24,7 @@
 
 ## Get Started
 
-- Familiarize yourself with the [Principles of Solid Design System](https://solid-design-system.fe.union-investment.de/x.x.x/storybook/), which serves as a reference for design guidelines, components, and patterns used in this project. Adhering to these principles will help maintain consistency and a cohesive user experience.
+- Familiarize yourself with the [Principles of Solid Design System](https://solid-design-system.fe.union-investment.de/docs/), which serves as a reference for design guidelines, components, and patterns used in this project. Adhering to these principles will help maintain consistency and a cohesive user experience.
 
 - Have a look at the [demo project](https://solid-design-system.github.io/solid-design-system-demo/) to get a better understanding of the design system and its components. You can even [install it locally and play around](https://github.com/solid-design-system/solid-design-system-demo) to explore its features and functionalities.
 
@@ -67,7 +67,7 @@ We present the library in a [Storybook](https://storybook.js.org/) running on th
 - **COMPONENTS**: Web Components built with Lit JS. Often more complex than Styles, and could feature reactivity, state, multiple slots, properties, and more.
 - **UTILITIES**: Web Components built with Lit JS, used as SDS-internal helper components. Technically necessary to build other components and generic enough to be used multiple times. Not officially part of the design system library and no respective component existing in Figma.
 - **STYLES**: These are standalone CSS files. They don't provide any logic and are often non-interactive.
-- **PATTERN**: Demonstrate how to combine several components to solve a specific problem.
+- **TEMPLATES**: Demonstrate how to combine several components to solve a specific problem.
 - **LEGAL**: Contains legal information.
 
 Each component / utility / style / pattern contains both [docs](https://storybook.js.org/addons/@storybook/addon-docs) and [stories](https://storybook.js.org/docs/writing-stories):

--- a/DEVELOPER_STARTING_GUIDE.md
+++ b/DEVELOPER_STARTING_GUIDE.md
@@ -26,8 +26,6 @@
 
 - Familiarize yourself with the [Principles of Solid Design System](https://solid-design-system.fe.union-investment.de/docs/), which serves as a reference for design guidelines, components, and patterns used in this project. Adhering to these principles will help maintain consistency and a cohesive user experience.
 
-- Have a look at the [demo project](https://solid-design-system.github.io/solid-design-system-demo/) to get a better understanding of the design system and its components. You can even [install it locally and play around](https://github.com/solid-design-system/solid-design-system-demo) to explore its features and functionalities.
-
 - Solid Components follows a monorepo structure with packages (e. g. `components`) managed by `pnpm` (which is a replacement for `npm`). Linting and Formatting is centralized at root level. Packages have to be run individually (e.g. `cd packages/components && pnpm dev` to start development server). Run `pnpm verify` at the root directory periodically, particularly, before pushing changes when a pull request is already opened.
 
 ## SOLID Library Concepts


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
<!-- *PR notes: Please describe the changes in this PR.* -->
As a new joined developer on the SDS team, I would like to see an updated version of the `DEVELOPER_STARTING_GUIDE.md`.

This PR addresses some outdated documentation on the developer starting guide.
Section regarding a `demo-project` has been removed since it redirects to a 404 page and hasn't been updated for a long time.

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [x] Documentation is created/updated
