### PR TITLE
fix: improve sd-tag a11y

### DIFF
--- a/packages/components/src/components/tag/tag.test.ts
+++ b/packages/components/src/components/tag/tag.test.ts
@@ -31,6 +31,12 @@ describe('<sd-tag>', () => {
       el = await fixture<SdTag>(html`<sd-tag>Tag</sd-tag>`);
       expect(el.innerText).to.eq('Tag');
     });
+
+    it('should not have the aria-pressed attribute', async () => {
+      el = await fixture<SdTag>(html`<sd-tag>Tag</sd-tag>`);
+      const button = el.shadowRoot!.querySelector('button');
+      expect(button?.getAttribute('aria-pressed')).to.equal(null);
+    });
   });
 
   sizes.forEach(size => {
@@ -46,6 +52,20 @@ describe('<sd-tag>', () => {
     it('should pass accessibility tests', async () => {
       el = await fixture<SdTag>(html`<sd-tag selected>Tag</sd-tag>`);
       await expect(el).to.be.accessible();
+    });
+  });
+
+  describe('when toggleable', () => {
+    it('should have aria-pressed as true when selected', async () => {
+      el = await fixture<SdTag>(html`<sd-tag toggleable selected>Tag</sd-tag>`);
+      const button = el.shadowRoot!.querySelector('button');
+      expect(button?.getAttribute('aria-pressed')).to.equal('true');
+    });
+
+    it('should have aria-pressed as false when not selected', async () => {
+      el = await fixture<SdTag>(html`<sd-tag toggleable>Tag</sd-tag>`);
+      const button = el.shadowRoot!.querySelector('button');
+      expect(button?.getAttribute('aria-pressed')).to.equal('false');
     });
   });
 

--- a/packages/components/src/components/tag/tag.ts
+++ b/packages/components/src/components/tag/tag.ts
@@ -33,6 +33,9 @@ export default class SdTag extends SolidElement {
   /** Displays the tag in a selected state. */
   @property({ type: Boolean, reflect: true }) selected = false;
 
+  /** Defines the tag as toggleable, adding the `aria-pressed` attribute to indicate its selected state */
+  @property({ type: Boolean, reflect: true }) toggleable = false;
+
   /** Displays the tag with a removability indicator. */
   @property({ type: Boolean, reflect: true }) removable = false;
 
@@ -95,6 +98,7 @@ export default class SdTag extends SolidElement {
         download=${ifDefined(isLink ? this.download : undefined)}
         ?disabled=${ifDefined(isLink ? undefined : this.disabled)}
         aria-disabled=${this.disabled ? 'true' : 'false'}
+        aria-pressed=${ifDefined(this.toggleable ? this.selected : undefined)}
         tabindex=${this.disabled ? '-1' : '0'}
         @blur=${this.handleBlur}
         @focus=${this.handleFocus}

--- a/packages/docs/src/stories/components/tag.stories.ts
+++ b/packages/docs/src/stories/components/tag.stories.ts
@@ -51,12 +51,15 @@ export const Size = {
 
 /**
  * Use the `selected` attribute to enable the selected state.
+ *
+ * __Accessibility hint__: Use the attribute `toggleable` to reflect the `selected` state on the `aria-pressed` attribute.
  */
 
 export const Selected = {
   render: () => html`
     <div class="flex gap-12">
-      <sd-tag selected>Selected</sd-tag>
+      <sd-tag selected toggleable>Selected</sd-tag>
+      <sd-tag toggleable>Unselected</sd-tag>
     </div>
   `
 };

--- a/packages/docs/src/stories/components/tag.stories.ts
+++ b/packages/docs/src/stories/components/tag.stories.ts
@@ -57,10 +57,22 @@ export const Size = {
 
 export const Selected = {
   render: () => html`
-    <div class="flex gap-12">
+    <div id="tags-selected" class="flex gap-12">
       <sd-tag selected toggleable>Selected</sd-tag>
       <sd-tag toggleable>Unselected</sd-tag>
     </div>
+
+    <script>
+      const handleToggle = event => {
+        const tag = event.target;
+        tag.toggleAttribute('selected');
+        const isSelected = tag.hasAttribute('selected');
+        tag.innerText = isSelected ? 'Selected' : 'Unselected';
+      };
+
+      const tags = document.querySelectorAll('#tags-selected sd-tag');
+      tags.forEach(tag => tag.addEventListener('click', handleToggle));
+    </script>
   `
 };
 

--- a/packages/docs/src/stories/components/tag.stories.ts
+++ b/packages/docs/src/stories/components/tag.stories.ts
@@ -62,7 +62,7 @@ export const Selected = {
       <sd-tag toggleable>Unselected</sd-tag>
     </div>
 
-    <script>
+    <script type="module">
       const handleToggle = event => {
         const tag = event.target;
         tag.toggleAttribute('selected');
@@ -86,7 +86,7 @@ export const Removable = {
       <sd-tag size="lg" removable>Removable</sd-tag>
     </div>
 
-    <script>
+    <script type="module">
       const tag = document.querySelector('#tags-removable');
 
       tag.addEventListener('sd-remove', event => {

--- a/packages/docs/src/stories/components/tag.stories.ts
+++ b/packages/docs/src/stories/components/tag.stories.ts
@@ -59,7 +59,6 @@ export const Selected = {
   render: () => html`
     <div id="tags-selected" class="flex gap-12">
       <sd-tag selected toggleable>Selected</sd-tag>
-      <sd-tag toggleable>Unselected</sd-tag>
     </div>
 
     <script type="module">

--- a/packages/docs/src/stories/templates/tag.stories.ts
+++ b/packages/docs/src/stories/templates/tag.stories.ts
@@ -15,16 +15,16 @@ export default {
 
 export const filterTagGroup = {
   render: () => html`
-    <sd-tag selected>All</sd-tag>
-    <sd-tag>Extended Reality</sd-tag>
-    <sd-tag>Internet of things</sd-tag>
+    <sd-tag toggleable selected>All</sd-tag>
+    <sd-tag toggleable>Extended Reality</sd-tag>
+    <sd-tag toggleable>Internet of things</sd-tag>
   `
 };
 
 export const filterTagGroupMorningstarRating = {
   name: 'Filter Tag Group with Morningstar Rating',
   render: () => html`
-    <sd-tag selected>
+    <sd-tag toggleable selected>
       <label class="sr-only">5 stars</label>
       <sd-icon name="system/star-filled" color="currentColor"></sd-icon>
       <sd-icon name="system/star-filled" color="currentColor"></sd-icon>
@@ -32,25 +32,25 @@ export const filterTagGroupMorningstarRating = {
       <sd-icon name="system/star-filled" color="currentColor"></sd-icon>
       <sd-icon name="system/star-filled" color="currentColor"></sd-icon>
     </sd-tag>
-    <sd-tag>
+    <sd-tag toggleable>
       <label class="sr-only">4 stars</label>
       <sd-icon name="system/star-filled" color="currentColor"></sd-icon>
       <sd-icon name="system/star-filled" color="currentColor"></sd-icon>
       <sd-icon name="system/star-filled" color="currentColor"></sd-icon>
       <sd-icon name="system/star-filled" color="currentColor"></sd-icon>
     </sd-tag>
-    <sd-tag>
+    <sd-tag toggleable>
       <label class="sr-only">3 stars</label>
       <sd-icon name="system/star-filled" color="currentColor"></sd-icon>
       <sd-icon name="system/star-filled" color="currentColor"></sd-icon>
       <sd-icon name="system/star-filled" color="currentColor"></sd-icon>
     </sd-tag>
-    <sd-tag>
+    <sd-tag toggleable>
       <label class="sr-only">2 stars</label>
       <sd-icon name="system/star-filled" color="currentColor"></sd-icon>
       <sd-icon name="system/star-filled" color="currentColor"></sd-icon>
     </sd-tag>
-    <sd-tag>
+    <sd-tag toggleable>
       <label class="sr-only">1 star</label>
       <sd-icon name="system/star-filled" color="currentColor"></sd-icon>
     </sd-tag>
@@ -60,23 +60,23 @@ export const filterTagGroupMorningstarRating = {
 export const filterTagGroupRisk = {
   name: 'Filter Tag Group with Risk',
   render: () =>
-    html`<sd-tag selected>
+    html`<sd-tag toggleable selected>
         <div class="h-4 w-4 bg-risk-veryhigh border-primary-800 border-[1px]"></div>
         Very High Risk
       </sd-tag>
-      <sd-tag>
+      <sd-tag toggleable>
         <div class="h-4 w-4 bg-risk-high border-primary-800 border-[1px]"></div>
         High Risk
       </sd-tag>
-      <sd-tag>
+      <sd-tag toggleable>
         <div class="h-4 w-4 bg-risk-increased border-primary-800 border-[1px]"></div>
         Increased Risk
       </sd-tag>
-      <sd-tag>
+      <sd-tag toggleable>
         <div class="h-4 w-4 bg-risk-moderate border-primary-800 border-[1px]"></div>
         Moderated Risk
       </sd-tag>
-      <sd-tag>
+      <sd-tag toggleable>
         <div class="h-4 w-4 bg-risk-low border-primary-800 border-[1px]"></div>
         Low Risk
       </sd-tag>`


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
<!-- *PR notes: Please describe the changes in this PR.* -->
Closes #1490

Goal: Implement `aria-pressed` on the sd-tag and a `toggleable` attribute to control whenever the `aria-pressed` should show or not.

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [x] Documentation is created/updated
- [x] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [x] Stories (features, a11y) are created/updated
- [x] relevant tickets are linked
