### PR TITLE
fix: improve sd-switch a11y

### DIFF
--- a/packages/components/src/components/switch/switch.test.ts
+++ b/packages/components/src/components/switch/switch.test.ts
@@ -96,6 +96,34 @@ describe('<sd-switch>', () => {
     await el.updateComplete;
   });
 
+  describe('should contain aria-invalid', () => {
+    it('as false when required, checked and touched', async () => {
+      const sdSwitch = await fixture<HTMLFormElement>(html` <sd-switch required></sd-switch> `);
+      const input = sdSwitch.shadowRoot!.querySelector('input')!;
+
+      sdSwitch.click();
+      await sdSwitch.updateComplete;
+
+      expect(input.getAttribute('aria-invalid')).to.equal('false');
+    });
+
+    it('as false when required, unchecked and untouched', async () => {
+      const sdSwitch = await fixture<HTMLFormElement>(html` <sd-switch required></sd-switch> `);
+      const input = sdSwitch.shadowRoot!.querySelector('input')!;
+      expect(input.getAttribute('aria-invalid')).to.equal('false');
+    });
+
+    it('as true when required, unchecked and touched', async () => {
+      const sdSwitch = await fixture<SdSwitch>(html`<sd-switch required checked></sd-switch>`);
+      const input = sdSwitch.shadowRoot!.querySelector('input')!;
+
+      sdSwitch.click();
+      await waitUntil(() => input.getAttribute('aria-invalid') === 'true');
+
+      expect(input.getAttribute('aria-invalid')).to.equal('true');
+    });
+  });
+
   describe('when submitting a form', () => {
     it('should submit the correct value when a value is provided', async () => {
       const form = await fixture<HTMLFormElement>(html`
@@ -148,7 +176,6 @@ describe('<sd-switch>', () => {
       sdSwitch.setCustomValidity('Invalid selection');
       await sdSwitch.updateComplete;
 
-      expect(sdSwitch.checkValidity()).to.be.false;
       expect(sdSwitch.checkValidity()).to.be.false;
       expect(sdSwitch.hasAttribute('data-invalid')).to.be.true;
       expect(sdSwitch.hasAttribute('data-valid')).to.be.false;

--- a/packages/components/src/components/switch/switch.ts
+++ b/packages/components/src/components/switch/switch.ts
@@ -173,6 +173,7 @@ export default class SdSwitch extends SolidElement implements SolidFormControl {
           id="input"
           class="peer absolute opacity-0 p-0 m-0 pointer-events-none"
           type="checkbox"
+          role="switch"
           title=${this.title /* An empty title prevents browser validation tooltips from appearing on hover */}
           name=${this.name}
           value=${ifDefined(this.value)}
@@ -180,6 +181,8 @@ export default class SdSwitch extends SolidElement implements SolidFormControl {
           .disabled=${this.disabled}
           .required=${this.required}
           aria-checked=${this.checked ? 'true' : 'false'}
+          aria-invalid=${this.showInvalidStyle}
+          aria-describedby="invalid-message"
           @click=${this.handleClick}
           @input=${this.handleInput}
           @invalid=${this.handleInvalid}


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
<!-- *PR notes: Please describe the changes in this PR.* -->
Close #1488

Goals:
- [x] `aria-invalid` is implemented on the input
- [x] `invalid-message` is semantically connected
- [x] input role replaced by `switch` since there are only two states to the component.

Note: While testing using a screen reader, before replacing the role to `switch`, it would read as `on tick box` or `off tick box`. After replacing the role, it now reads as `on switch` or `off switch`. Since it reads out as `switch`, the user assumes it has only 2 possible states, which is true.

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [x] E2E tests (features, a11y, bug fixes) are created/updated
- [x] relevant tickets are linked
