### PR TITLE
fix: improve table template a11y

### DIFF
--- a/packages/docs/src/stories/templates/table.stories.ts
+++ b/packages/docs/src/stories/templates/table.stories.ts
@@ -520,6 +520,15 @@ export const TableFixedBottom = {
         });
       </script>
       <table id="vertical-scrollable-table-2" class="sd-table sample-table h-[200px] block overflow-y-scroll">
+        <thead class="sr-only">
+          <tr>
+            <th>Header</th>
+            <th>Header</th>
+            <th>Header</th>
+            <th>Header</th>
+            <th>Header</th>
+          </tr>
+        </thead>
         <tbody>
           <tr>
             <td class="sd-table-cell sd-table-cell--bg-transparent">Cell content</td>
@@ -620,104 +629,118 @@ export const TableFixedLeft = {
       </script>
       <div id="horizontal-scrollable-table-2" class="overflow-x-scroll overflow-y-visible w-[600px]">
         <table class="sd-table sample-table">
-          <tr>
-            <th
-              class="sd-table-cell top-auto sticky left-0 z-[2] bg-clip-padding sd-table-cell--shadow-right sd-table-cell--shadow-active sd-table-cell--bg-white"
-            >
-              Header
-            </th>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-          </tr>
-          <tr>
-            <th
-              class="sd-table-cell top-auto sticky left-0 z-[2] bg-clip-padding sd-table-cell--shadow-right sd-table-cell--shadow-active sd-table-cell--bg-primary-100"
-            >
-              Header
-            </th>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
-          </tr>
-          <tr>
-            <th
-              class="sd-table-cell top-auto sticky left-0 z-[2] bg-clip-padding sd-table-cell--shadow-right sd-table-cell--shadow-active sd-table-cell--bg-white"
-            >
-              Header
-            </th>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-          </tr>
-          <tr>
-            <th
-              class="sd-table-cell top-auto sticky left-0 z-[2] bg-clip-padding sd-table-cell--shadow-right sd-table-cell--shadow-active sd-table-cell--bg-primary-100"
-            >
-              Header
-            </th>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
-          </tr>
-          <tr>
-            <th
-              class="sd-table-cell top-auto sticky left-0 z-[2] bg-clip-padding sd-table-cell--shadow-right sd-table-cell--shadow-active sd-table-cell--bg-white"
-            >
-              Header
-            </th>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-          </tr>
-          <tr>
-            <th
-              class="sd-table-cell top-auto sticky left-0 z-[2] bg-clip-padding sd-table-cell--shadow-right sd-table-cell--shadow-active sd-table-cell--bg-primary-100"
-            >
-              Header
-            </th>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
-          </tr>
-          <tr>
-            <th
-              class="sd-table-cell top-auto sticky left-0 z-[2] bg-clip-padding sd-table-cell--shadow-right sd-table-cell--shadow-active sd-table-cell--bg-white"
-            >
-              Header
-            </th>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-            <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-          </tr>
+          <thead class="sr-only">
+            <tr>
+              <th></th>
+              <th>Header</th>
+              <th>Header</th>
+              <th>Header</th>
+              <th>Header</th>
+              <th>Header</th>
+              <th>Header</th>
+              <th>Header</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th
+                class="sd-table-cell top-auto sticky left-0 z-[2] bg-clip-padding sd-table-cell--shadow-right sd-table-cell--shadow-active sd-table-cell--bg-white"
+              >
+                Header
+              </th>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+            </tr>
+            <tr>
+              <th
+                class="sd-table-cell top-auto sticky left-0 z-[2] bg-clip-padding sd-table-cell--shadow-right sd-table-cell--shadow-active sd-table-cell--bg-primary-100"
+              >
+                Header
+              </th>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
+            </tr>
+            <tr>
+              <th
+                class="sd-table-cell top-auto sticky left-0 z-[2] bg-clip-padding sd-table-cell--shadow-right sd-table-cell--shadow-active sd-table-cell--bg-white"
+              >
+                Header
+              </th>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+            </tr>
+            <tr>
+              <th
+                class="sd-table-cell top-auto sticky left-0 z-[2] bg-clip-padding sd-table-cell--shadow-right sd-table-cell--shadow-active sd-table-cell--bg-primary-100"
+              >
+                Header
+              </th>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
+            </tr>
+            <tr>
+              <th
+                class="sd-table-cell top-auto sticky left-0 z-[2] bg-clip-padding sd-table-cell--shadow-right sd-table-cell--shadow-active sd-table-cell--bg-white"
+              >
+                Header
+              </th>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+            </tr>
+            <tr>
+              <th
+                class="sd-table-cell top-auto sticky left-0 z-[2] bg-clip-padding sd-table-cell--shadow-right sd-table-cell--shadow-active sd-table-cell--bg-primary-100"
+              >
+                Header
+              </th>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-primary-100">Cell content</td>
+            </tr>
+            <tr>
+              <th
+                class="sd-table-cell top-auto sticky left-0 z-[2] bg-clip-padding sd-table-cell--shadow-right sd-table-cell--shadow-active sd-table-cell--bg-white"
+              >
+                Header
+              </th>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+            </tr>
+          </tbody>
         </table>
       </div>
     `;
@@ -747,90 +770,102 @@ export const TableFixedRight = {
         </script>
         <div id="horizontal-scrollable-table-2" class="overflow-x-scroll overflow-y-visible w-[600px]">
           <table class="sd-table sample-table">
-            <tr>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-              <th class="sd-table-cell left-0 top-auto sticky right-0 z-[2] sd-table-cell--shadow-left sd-table-cell--shadow-active sd-table-cell--bg-white">
-              Header
-            </th>
-            </tr>
-            <tr>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
-              <th class="sd-table-cell left-0 top-auto sticky right-0 z-[2] sd-table-cell--shadow-left sd-table-cell--shadow-active sd-table-cell--bg-neutral-100">
+            <thead class="sr-only">
+              <th>Header</th>
+              <th>Header</th>
+              <th>Header</th>
+              <th>Header</th>
+              <th>Header</th>
+              <th>Header</th>
+              <th>Header</th>
+              <th></th>
+            </thead>
+            <tbody>
+              <tr>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+                <th class="sd-table-cell left-0 top-auto sticky right-0 z-[2] sd-table-cell--shadow-left sd-table-cell--shadow-active sd-table-cell--bg-white">
                 Header
               </th>
-            </tr>
-            <tr>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-              <th class="sd-table-cell left-0 top-auto sticky right-0 z-[2] sd-table-cell--shadow-left sd-table-cell--shadow-active sd-table-cell--bg-white">
-                Header
-              </th>
-            </tr>
-            <tr>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
-              <th class="sd-table-cell left-0 top-auto sticky right-0 z-[2] sd-table-cell--shadow-left sd-table-cell--shadow-active sd-table-cell--bg-neutral-100">
-                Header
-              </th>
-            </tr>
-            <tr>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-              <th class="sd-table-cell left-0 top-auto sticky right-0 z-[2] sd-table-cell--shadow-left sd-table-cell--shadow-active sd-table-cell--bg-white">
-                Header
-              </th>
-            </tr>
-            <tr>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
-              <th class="sd-table-cell left-0 top-auto sticky right-0 z-[2] sd-table-cell--shadow-left sd-table-cell--shadow-active sd-table-cell--bg-neutral-100">
-                Header
-              </th>
-            </tr>
-            <tr>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-              <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
-              <th class="sd-table-cell left-0 top-auto sticky right-0 z-[2] sd-table-cell--shadow-left sd-table-cell--shadow-active sd-table-cell--bg-white">
-                Header
-              </th>
-            </tr>
+              </tr>
+              <tr>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
+                <th class="sd-table-cell left-0 top-auto sticky right-0 z-[2] sd-table-cell--shadow-left sd-table-cell--shadow-active sd-table-cell--bg-neutral-100">
+                  Header
+                </th>
+              </tr>
+              <tr>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+                <th class="sd-table-cell left-0 top-auto sticky right-0 z-[2] sd-table-cell--shadow-left sd-table-cell--shadow-active sd-table-cell--bg-white">
+                  Header
+                </th>
+              </tr>
+              <tr>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
+                <th class="sd-table-cell left-0 top-auto sticky right-0 z-[2] sd-table-cell--shadow-left sd-table-cell--shadow-active sd-table-cell--bg-neutral-100">
+                  Header
+                </th>
+              </tr>
+              <tr>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+                <th class="sd-table-cell left-0 top-auto sticky right-0 z-[2] sd-table-cell--shadow-left sd-table-cell--shadow-active sd-table-cell--bg-white">
+                  Header
+                </th>
+              </tr>
+              <tr>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-neutral-100">Cell content</td>
+                <th class="sd-table-cell left-0 top-auto sticky right-0 z-[2] sd-table-cell--shadow-left sd-table-cell--shadow-active sd-table-cell--bg-neutral-100">
+                  Header
+                </th>
+              </tr>
+              <tr>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+                <td class="sd-table-cell text-nowrap whitespace-nowrap sd-table-cell--bg-white">Cell content</td>
+                <th class="sd-table-cell left-0 top-auto sticky right-0 z-[2] sd-table-cell--shadow-left sd-table-cell--shadow-active sd-table-cell--bg-white">
+                  Header
+                </th>
+              </tr>
+            </tbody>
           </table>
         </div>
       </div>

--- a/packages/docs/src/stories/templates/table.stories.ts
+++ b/packages/docs/src/stories/templates/table.stories.ts
@@ -6,6 +6,10 @@ import { ifDefined } from 'lit/directives/if-defined.js';
  * These examples demonstrate the usage of sd-table-cell in various contexts.
  * The examples are intended solely for illustrating how sd-table-cell can be used to style tables.
  * The data generation and table sorting logic should not be used in production environments.
+ *
+ * **Accessibility Hint:** Whenever the table doesn't contain interactive elements,
+ * wrap the table inside a scrollable region using `role="region"`, `tabindex="0"` and `aria-label`,
+ * to ensure it becomes accessible to keyboard only users.
  */
 export default {
   tags: ['!dev'],
@@ -20,7 +24,12 @@ export default {
  */
 export const simpleTables = {
   render: () => html`
-    <table class="sd-table sample-table w-full">
+    <table
+      class="sd-table sample-table w-full focus-visible:focus-outline"
+      role="region"
+      tabindex="0"
+      aria-label="Simple table"
+    >
       <thead>
         <tr>
           <th class="sd-table-cell sd-table-cell--bg-white">Header</th>
@@ -92,7 +101,12 @@ export const simpleTables = {
 export const simpleTableVerticalDividers = {
   name: 'Simple Table with Vertical Dividers',
   render: () => html`
-    <table class="sd-table sample-table w-full">
+    <table
+      class="sd-table sample-table w-full focus-visible:focus-outline"
+      role="region"
+      tabindex="0"
+      aria-label="Simple Table with Vertical Dividers"
+    >
       <thead>
         <tr>
           <th class="sd-table-cell sd-table-cell--bg-white sd-table-cell--divider">Header</th>
@@ -164,7 +178,12 @@ export const simpleTableVerticalDividers = {
 export const simpleTableAlternatingColors = {
   name: 'Simple Table with Alternating Colors',
   render: () => html`
-    <table class="sd-table sample-table w-full">
+    <table
+      class="sd-table sample-table w-full focus-visible:focus-outline"
+      role="region"
+      tabindex="0"
+      aria-label="Simple Table with Alternating Colors"
+    >
       <thead>
         <tr>
           <th class="sd-table-cell sd-table-cell--bg-primary-100">Header</th>
@@ -454,7 +473,13 @@ export const advancedTables = {
           });
         });
       </script>
-      <table id="vertical-scrollable-table" class="sd-table sample-table h-[200px] overflow-y-scroll block">
+      <table
+        id="vertical-scrollable-table"
+        class="sd-table sample-table h-[200px] overflow-y-scroll block focus-visible:focus-outline"
+        role="region"
+        tabindex="0"
+        aria-label="Table with Fixed Top Header Row and Shadow"
+      >
         <thead>
           <tr>
             <th class="sd-table-cell sd-table-cell--bg-white sticky top-0 sd-table-cell--shadow-bottom">Header</th>
@@ -519,7 +544,13 @@ export const TableFixedBottom = {
           });
         });
       </script>
-      <table id="vertical-scrollable-table-2" class="sd-table sample-table h-[200px] block overflow-y-scroll">
+      <table
+        id="vertical-scrollable-table-2"
+        class="sd-table sample-table h-[200px] block overflow-y-scroll focus-visible:focus-outline"
+        role="region"
+        tabindex="0"
+        aria-label="Table with Fixed Bottom Header Row and Shadow"
+      >
         <thead class="sr-only">
           <tr>
             <th>Header</th>
@@ -627,7 +658,13 @@ export const TableFixedLeft = {
           });
         });
       </script>
-      <div id="horizontal-scrollable-table-2" class="overflow-x-scroll overflow-y-visible w-[600px]">
+      <div
+        id="horizontal-scrollable-table-2"
+        class="overflow-x-scroll overflow-y-visible w-[600px] focus-visible:focus-outline"
+        role="region"
+        tabindex="0"
+        aria-label="Table with Fixed Left Header Column and Shadow"
+      >
         <table class="sd-table sample-table">
           <thead class="sr-only">
             <tr>
@@ -768,7 +805,13 @@ export const TableFixedRight = {
             });
           });
         </script>
-        <div id="horizontal-scrollable-table-2" class="overflow-x-scroll overflow-y-visible w-[600px]">
+        <div
+          id="horizontal-scrollable-table-2"
+          class="overflow-x-scroll overflow-y-visible w-[600px] focus-visible:focus-outline"
+          role="region"
+          tabindex="0"
+          aria-label="Table with Fixed Right Header Column and Shadow"
+        >
           <table class="sd-table sample-table">
             <thead class="sr-only">
               <th>Header</th>


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
Closes #1534

Goals:
- [x] Tables without interactive elements are not reachable via keyboard. Wrap tables with `role="region"`and `tabindex="0"`
- [x] Usage of `role="status"` to announce to screen readers when sort status has changed.
- [x] Implement `sr-only` `thead` to tables with fixed left, right and bottom headers.

---

`role="region"` identifies a significant document area, a part from `role="group"` which is not so significant and is even used on areas that are not intended to be included in a page summary.

>The region role is used to identify document areas the author deems significant. It is a generic landmark available to aid in navigation when none of the other landmark roles are appropriate.

>The group role identifies a set of user interface objects that is not intended to be included in a page summary or table of contents by assistive technologies.

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [x] Documentation is created/updated
- [x] Stories (features, a11y) are created/updated
- [x] relevant tickets are linked
