### PR TITLE
chore: replace usage of bg-neutral-400 with border-neutral-400

### DIFF
--- a/packages/components/src/components/notification/notification.ts
+++ b/packages/components/src/components/notification/notification.ts
@@ -282,7 +282,10 @@ export default class SdNotification extends SolidElement {
                 style=${`animation-duration: ${this.duration}ms`}
                 class=${cx(`absolute w-0 h-[2px] bottom-0 bg-primary z-10 animate-grow`)}
               ></div>
-              <div part="duration-indicator__total" class="w-full h-[2px] bottom-0 absolute bg-neutral-400"></div>
+              <div
+                part="duration-indicator__total"
+                class="w-full h-[2px] bottom-0 absolute border border-neutral-400"
+              ></div>
             `
           : ''}
       </div>

--- a/packages/components/src/components/tab-group/tab-group.ts
+++ b/packages/components/src/components/tab-group/tab-group.ts
@@ -338,7 +338,7 @@ export default class SdTabGroup extends SolidElement {
 
           <div part="scroll-container" class="flex overflow-x-auto focus-visible:focus-outline !outline-offset-0">
             <div part="tabs" class=${cx('flex flex-auto relative flex-row')} role="tablist">
-              <div part="separation" class="w-full h-0.25 bg-neutral-400 absolute bottom-0"></div>
+              <div part="separation" class="w-full h-0.25 border-[0.5px] border-neutral-400 absolute bottom-0"></div>
               <slot name="nav" @slotchange=${this.syncTabsAndPanels}></slot>
             </div>
           </div>

--- a/packages/components/src/components/tab-group/tab-group.ts
+++ b/packages/components/src/components/tab-group/tab-group.ts
@@ -338,7 +338,7 @@ export default class SdTabGroup extends SolidElement {
 
           <div part="scroll-container" class="flex overflow-x-auto focus-visible:focus-outline !outline-offset-0">
             <div part="tabs" class=${cx('flex flex-auto relative flex-row')} role="tablist">
-              <div part="separation" class="w-full h-0.25 border-[0.5px] border-neutral-400 absolute bottom-0"></div>
+              <div part="separation" class="w-full border-[0.25px] border-neutral-400 absolute bottom-0"></div>
               <slot name="nav" @slotchange=${this.syncTabsAndPanels}></slot>
             </div>
           </div>

--- a/packages/components/src/styles/table-cell/table-cell.css
+++ b/packages/components/src/styles/table-cell/table-cell.css
@@ -26,7 +26,7 @@
 
     /* fix that shows line on top of table-cell */
     &:before {
-      @apply bg-neutral-400 block content-[''] absolute w-full h-[1px] left-0;
+      @apply border-[0.5px] border-neutral-400 block content-[''] absolute w-full h-[1px] left-0;
     }
   }
 


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
This PR removes the usage of bg-neutral-400 from the codebase. It's required before merging [1671](https://github.com/solid-design-system/solid/pull/1671)

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
