### PR TITLE
fix: sd-flag improve a11y

### DIFF
--- a/.changeset/happy-pumas-travel.md
+++ b/.changeset/happy-pumas-travel.md
@@ -1,0 +1,7 @@
+---
+'@solid-design-system/components': patch
+---
+
+Improved sd-flag a11y:
+
+- Change text color on bg neutral-500 from white to black to comply with WCAG 2.2

--- a/packages/components/src/styles/flag/flag.css
+++ b/packages/components/src/styles/flag/flag.css
@@ -2,7 +2,7 @@
   @apply h-8 bg-neutral-200 text-black text-sm inline-flex items-center px-3 whitespace-nowrap overflow-hidden;
 
   &--neutral-500 {
-    @apply bg-neutral-500 text-white;
+    @apply bg-neutral-500 text-black;
   }
 
   &--neutral-300 {


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
Closes https://github.com/solid-design-system/solid/issues/1611 and https://github.com/solid-design-system/solid/issues/1530

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [x] Documentation is created/updated
- [x] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [x] relevant tickets are linked
