### PR TITLE
fix: improve sd-dropdown a11y

### DIFF
--- a/.changeset/eight-bats-roll.md
+++ b/.changeset/eight-bats-roll.md
@@ -6,4 +6,4 @@
 Improved sd-dropdown a11y:
 
 - Correctly label icon-button dropdown triggers.
-- Fix focus on trigger after dropdown is hidden using keyboard.
+- Fix focus on the trigger after the dropdown is hidden using the keyboard.

--- a/.changeset/eight-bats-roll.md
+++ b/.changeset/eight-bats-roll.md
@@ -1,0 +1,9 @@
+---
+'@solid-design-system/components': patch
+'@solid-design-system/docs': patch
+---
+
+Improved sd-dropdown a11y:
+
+- Correctly label icon-button dropdown triggers.
+- Fix focus on trigger after dropdown is hidden using keyboard.

--- a/packages/components/src/components/dropdown/dropdown.ts
+++ b/packages/components/src/components/dropdown/dropdown.ts
@@ -15,6 +15,7 @@ import SolidElement from '../../internal/solid-element';
 import type SdButton from '../button/button';
 import type SdMenu from '../../_components/menu/menu'; // This import should be changed as soon as the menu is moved to the components folder
 import type SdMenuItem from '../../_components/menu-item/menu-item'; // This import should be changed as soon as the menu-item is moved to the components folder
+import type SdNavigationItem from '../navigation-item/navigation-item';
 import type SdPopup from '../popup/popup';
 
 /**
@@ -311,7 +312,7 @@ export default class SdDropdown extends SolidElement {
   updateAccessibleTrigger() {
     const assignedElements = this.trigger.assignedElements({ flatten: true }) as HTMLElement[];
     const accessibleTrigger = assignedElements.find(el => getTabbableBoundary(el).start);
-    let target: HTMLElement;
+    let target: HTMLElement | null;
 
     if (accessibleTrigger) {
       switch (accessibleTrigger.tagName.toLowerCase()) {
@@ -320,13 +321,15 @@ export default class SdDropdown extends SolidElement {
         case 'sd-icon-button':
           target = (accessibleTrigger as SdButton).button;
           break;
-
+        case 'sd-navigation-item':
+          target = (accessibleTrigger as SdNavigationItem).button;
+          break;
         default:
           target = accessibleTrigger;
       }
 
-      target.setAttribute('aria-haspopup', 'true');
-      target.setAttribute('aria-expanded', this.open ? 'true' : 'false');
+      target?.setAttribute('aria-haspopup', 'true');
+      target?.setAttribute('aria-expanded', this.open ? 'true' : 'false');
     }
   }
 

--- a/packages/components/src/components/navigation-item/navigation-item.ts
+++ b/packages/components/src/components/navigation-item/navigation-item.ts
@@ -3,7 +3,7 @@ import { customElement } from '../../internal/register-custom-element';
 import { HasSlotController } from '../../internal/slot';
 import { html, literal } from 'lit/static-html.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { property } from 'lit/decorators.js';
+import { property, query } from 'lit/decorators.js';
 import componentStyles from '../../styles/component.styles';
 import cx from 'classix';
 import InteractiveStyles from '../../styles/interactive/interactive.css?inline';
@@ -34,6 +34,8 @@ import SolidElement from '../../internal/solid-element';
 @customElement('sd-navigation-item')
 export default class SdNavigationItem extends SolidElement {
   private readonly hasSlotController = new HasSlotController(this, '[default]', 'description', 'children');
+
+  @query('a[part="base"], button[part="base"]') button: HTMLButtonElement | HTMLLinkElement | null;
 
   /** The navigation item's orientation. If false, properties below this point are not used. */
   @property({ type: Boolean, reflect: true }) vertical = false;

--- a/packages/components/src/internal/tabbable.ts
+++ b/packages/components/src/internal/tabbable.ts
@@ -23,7 +23,9 @@ function isTabbable(el: HTMLElement) {
   }
 
   // Elements that are hidden have no offsetParent and are not tabbable
-  if (el.offsetParent === null) {
+  // Elements when have the shadow root as a parent node, also have offsetParent as null,
+  // therefore, we need to check if elements parent is the shadow root.
+  if (el.offsetParent === null && !(el.getRootNode() instanceof ShadowRoot)) {
     return false;
   }
 

--- a/packages/docs/src/stories/components/dropdown.stories.ts
+++ b/packages/docs/src/stories/components/dropdown.stories.ts
@@ -141,7 +141,7 @@ export const Rounded = {
     <sd-dropdown open rounded distance="4">
       <div class="slot slot--border slot--text p-4 w-[300px]">Default slot</div>
       <sd-button slot="trigger" variant="secondary">
-        <sd-icon name="system/more-functions" class="h-6 w-6" label="Trigger rounded dropdown"></sd-icon>
+        <sd-icon name="system/more-functions" class="h-6 w-6" label="Rounded dropdown"></sd-icon>
       </sd-button>
     </sd-dropdown>
   `

--- a/packages/docs/src/stories/components/dropdown.stories.ts
+++ b/packages/docs/src/stories/components/dropdown.stories.ts
@@ -141,7 +141,7 @@ export const Rounded = {
     <sd-dropdown open rounded distance="4">
       <div class="slot slot--border slot--text p-4 w-[300px]">Default slot</div>
       <sd-button slot="trigger" variant="secondary">
-        <sd-icon name="system/more-functions" class="h-6 w-6"></sd-icon>
+        <sd-icon name="system/more-functions" class="h-6 w-6" label="Trigger rounded dropdown"></sd-icon>
       </sd-button>
     </sd-dropdown>
   `

--- a/packages/docs/src/stories/templates/dropdown.stories.ts
+++ b/packages/docs/src/stories/templates/dropdown.stories.ts
@@ -28,7 +28,7 @@ export const Default = {
 
     <sd-dropdown open>
       <sd-navigation-item slot="trigger" vertical>
-        <sd-icon name="system/globe" class="h-6 w-6"></sd-icon>
+        <sd-icon name="system/globe" class="h-6 w-6" label="Select a country"></sd-icon>
       </sd-navigation-item>
       <div class="flex flex-col p-2">
         <h4 class="sd-headline sd-headline--size-base p-4">Please select a country</h4>


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
Closes #1516 #1475 

This PR addresses:
- Correctly label icon-button dropdown triggers.
- Fix focus on the trigger after the dropdown is hidden using the keyboard.

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [x] Documentation is created/updated
- [x] Stories (features, a11y) are created/updated
- [x] relevant tickets are linked
