### PR TITLE
fix: improve sd-icon a11y

### DIFF
--- a/.changeset/tame-foxes-talk.md
+++ b/.changeset/tame-foxes-talk.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/components': patch
+---
+
+Implement `console.error` message on sd-icon when the label attribute is not set.

--- a/packages/components/src/components/icon/icon.ts
+++ b/packages/components/src/components/icon/icon.ts
@@ -52,6 +52,12 @@ export default class SdIcon extends SolidElement {
   connectedCallback() {
     super.connectedCallback();
     watchIcon(this);
+
+    if (!this.label) {
+      console.error(
+        '[solid-design-system]: The `label` prop is required for the `sd-icon` component to ensure accessibility. Please provide a descriptive label.'
+      );
+    }
   }
 
   firstUpdated() {


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
Closes #1498

This PR addresses:
- sd-icon throws a `console.error` when the label attribute is not set.

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [x] relevant tickets are linked
