### PR TITLE
fix: improve sd-divider a11y

### DIFF
--- a/.changeset/ninety-yaks-mix.md
+++ b/.changeset/ninety-yaks-mix.md
@@ -1,0 +1,7 @@
+---
+'@solid-design-system/components': patch
+---
+
+Improved sd-divider a11y:
+
+- Implemented aria-orientation attribute 

--- a/packages/components/src/components/divider/divider.test.ts
+++ b/packages/components/src/components/divider/divider.test.ts
@@ -13,6 +13,7 @@ describe('<sd-divider>', () => {
       const el = await fixture<SdDivider>(html` <sd-divider></sd-divider> `);
 
       expect(el.getAttribute('orientation')).to.equal('horizontal');
+      expect(el.shadowRoot?.querySelector('hr')?.getAttribute('aria-orientation')).to.equal('horizontal');
     });
 
     it('inverted defaults to false', async () => {
@@ -30,6 +31,7 @@ describe('<sd-divider>', () => {
       await elementUpdated(el);
 
       expect(el.getAttribute('orientation')).to.equal('vertical');
+      expect(el.shadowRoot?.querySelector('hr')?.getAttribute('aria-orientation')).to.equal('vertical');
     });
 
     it('inverted is updated', async () => {

--- a/packages/components/src/components/divider/divider.ts
+++ b/packages/components/src/components/divider/divider.ts
@@ -29,6 +29,7 @@ export default class SdDivider extends SolidElement {
     return html`
       <hr
         part="main"
+        aria-orientation=${this.orientation}
         class=${cx(
           this.inverted ? 'border-primary-400' : 'border-neutral-400',
           this.orientation === 'horizontal' ? 'border-t w-full' : ' border-l h-full'


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
Closes #1497 

This PR addresses:
- Implement `aria-orientation` on sd-divider

## Definition of Reviewable:
- [x] E2E tests (features, a11y, bug fixes) are created/updated
- [x] relevant tickets are linked
