### PR TITLE
fix: sd-hidden-links screenshot tests

### DIFF
--- a/.changeset/poor-beers-rule.md
+++ b/.changeset/poor-beers-rule.md
@@ -2,4 +2,4 @@
 '@solid-design-system/docs': patch
 ---
 
-Added the debug attribute to sd-hidden-links to display hidden links for screenshot tests.
+Added the debug class to sd-hidden-links to display hidden links for screenshot tests.

--- a/.changeset/poor-beers-rule.md
+++ b/.changeset/poor-beers-rule.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/docs': patch
+---
+
+Added the debug attribute to sd-hidden-links to display hidden links for screenshot tests.

--- a/packages/docs/src/stories/styles/hidden-links.stories.ts
+++ b/packages/docs/src/stories/styles/hidden-links.stories.ts
@@ -61,8 +61,8 @@ export const Default = {
 export const StackLinks = {
   render: () =>
     html`<div class="relative bg-white w-full h-[256px] p-8 flex">
-      <div class="sd-hidden-links"><sd-button href="#">Skip to Search</sd-button></div>
-      <div class="sd-hidden-links"><sd-button href="#">Skip to Content</sd-button></div>
+      <div class="sd-hidden-links"><sd-button href="#">Skip to search</sd-button></div>
+      <div class="sd-hidden-links"><sd-button href="#">Skip to content</sd-button></div>
       <p class="self-center">Tab through this area to see buttons one after another.</p>
     </div>`
 };

--- a/packages/docs/src/stories/styles/hidden-links.test.stories.ts
+++ b/packages/docs/src/stories/styles/hidden-links.test.stories.ts
@@ -29,7 +29,10 @@ export default {
     ...parameters,
     controls: { disable: true }
   },
-  args: overrideArgs({ type: 'slot', name: 'default', value: 'Lorem Ipsum' })
+  args: overrideArgs(
+    { type: 'slot', name: 'default', value: html`<sd-button href="#">Skip to content</sd-button>` },
+    { type: 'attribute', name: 'sd-hidden-links--debug', value: true }
+  )
 };
 
 /**
@@ -37,11 +40,6 @@ export default {
  */
 export const Default = {
   name: 'Default',
-  args: overrideArgs({
-    type: 'slot',
-    name: 'default',
-    value: html`<sd-button href="#">Skip to content</sd-button>`
-  }),
   render: (args: any) => {
     return generateTemplate({
       options: {
@@ -106,7 +104,9 @@ export const SurroundingContent = {
               }
             }
           </style>
-          <div class="%CLASSES%">%SLOT%</div>
+          <div class="relative z-20">
+            <div class="%CLASSES%">%SLOT%</div>
+          </div>
           <sd-header class="z-10" fixed>
             <div class="flex justify-between items-center">
               <!-- top-left-area start !-->
@@ -131,8 +131,8 @@ export const StackLinks = {
     return generateTemplate({
       options: {
         templateContent: html`<div class="relative bg-white w-full h-[256px] p-8">
-          <div class="sd-hidden-links"><sd-button href="#">Skip to content 1</sd-button></div>
-          <div class="sd-hidden-links"><sd-button href="#">Skip to content 2</sd-button></div>
+          <div class="sd-hidden-links sd-hidden-links--debug"><sd-button href="#">Skip to content 1</sd-button></div>
+          <div class="sd-hidden-links sd-hidden-links--debug"><sd-button href="#">Skip to content 2</sd-button></div>
           <p>Tab into this area to show a single button.</p>
         </div>`
       },
@@ -150,7 +150,7 @@ export const MultipleLinks = {
     return generateTemplate({
       options: {
         templateContent: html`<div class="relative bg-white w-full h-[256px] p-8">
-      <div class="sd-hidden-links sd-hidden-links--multiple">
+      <div class="sd-hidden-links sd-hidden-links--multiple sd-hidden-links--debug">
         <sd-navigation-item href="#">Search</sd-navigation-item>
         <sd-navigation-item href="#">Content</sd-navigation-item>
         <sd-navigation-item href="#">Footer</sd-navigation-item>
@@ -173,7 +173,7 @@ export const TitleForMultipleLinks = {
     return generateTemplate({
       options: {
         templateContent: html`<div class="relative bg-white w-full h-[256px] p-8" lang="de">
-            <div class="sd-hidden-links sd-hidden-links--multiple">
+            <div class="sd-hidden-links sd-hidden-links--multiple sd-hidden-links--debug">
               <sd-navigation-item href="#">Suche</sd-navigation-item>
               <sd-navigation-item href="#">Inhalt</sd-navigation-item>
               <sd-navigation-item href="#">Fußbereich</sd-navigation-item>
@@ -181,7 +181,7 @@ export const TitleForMultipleLinks = {
             <p>Hier wird eine deutsche Überschrift erscheinen.</p>
           </div>
           <div class="relative bg-white w-full h-[256px] p-8">
-            <div class="sd-hidden-links sd-hidden-links--multiple" lang="en">
+            <div class="sd-hidden-links sd-hidden-links--multiple sd-hidden-links--debug" lang="en">
               <sd-navigation-item href="#">Search</sd-navigation-item>
               <sd-navigation-item href="#">Content</sd-navigation-item>
               <sd-navigation-item href="#">Footer</sd-navigation-item>
@@ -194,7 +194,10 @@ export const TitleForMultipleLinks = {
                 --sd-hidden-links-title: 'Jump very fast to';
               }
             </style>
-            <div id="hidden-link-with-custom-title" class="sd-hidden-links sd-hidden-links--multiple">
+            <div
+              id="hidden-link-with-custom-title"
+              class="sd-hidden-links sd-hidden-links--multiple sd-hidden-links--debug"
+            >
               <sd-navigation-item href="#">Search</sd-navigation-item>
               <sd-navigation-item href="#">Content</sd-navigation-item>
               <sd-navigation-item href="#">Footer</sd-navigation-item>


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
Closes #1505 

This PR addresses:
- sd-hidden-links behind header due to z-index issue on screenshot test.
- added debug attribute to show sd-hidden-links on screenshot test.

## Definition of Reviewable:
- [x] Stories (features, a11y) are created/updated
- [x] relevant tickets are linked
