### PR TITLE
fix: fix disconnecedCallback in sd-tab-group

### DIFF
--- a/.changeset/tiny-walls-joke.md
+++ b/.changeset/tiny-walls-joke.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/components': patch
+---
+
+Fix a rare bug in the disconnecedCallback of sd-tab-group when being dynamically created and removed

--- a/packages/components/src/components/tab-group/tab-group.ts
+++ b/packages/components/src/components/tab-group/tab-group.ts
@@ -106,7 +106,10 @@ export default class SdTabGroup extends SolidElement {
 
   disconnectedCallback() {
     this.mutationObserver.disconnect();
-    this.resizeObserver.unobserve(this.nav);
+
+    if (this.nav) {
+      this.resizeObserver?.unobserve(this.nav);
+    }
   }
 
   private getAllTabs(options: { includeDisabled: boolean } = { includeDisabled: true }) {


### PR DESCRIPTION
This PR was created coming from a bug that was described in MS Teams. It replicated the changes from Shoelace: https://github.com/shoelace-style/shoelace/blob/6761fdceca3bfa7d5f78097c30db0a9cfbd88d6f/src/components/tab-group/tab-group.component.ts#L142

It is hard to create a test for this, that's why this was omitted.
