### PR TITLE
fix: codepen urls

### DIFF
--- a/.changeset/silent-goats-unite.md
+++ b/.changeset/silent-goats-unite.md
@@ -1,0 +1,7 @@
+---
+'@solid-design-system/docs': patch
+---
+
+Fix urls in `docs-codepen-enhancer` so that the correct files are loaded within Codepen editor.
+
+`https://solid-design-system.fe.union-investment.de/components/4.0.1/solid-components.bundle.js` -> `https://solid-design-system.fe.union-investment.de/components/4.0.1/cdn/solid-components.bundle.js`

--- a/packages/docs/scripts/storybook/docs-codepen-enhancer.ts
+++ b/packages/docs/scripts/storybook/docs-codepen-enhancer.ts
@@ -7,32 +7,38 @@ export default function docsCodepenEnhancer(code: string, storyContext: StoryCon
   const storiesOnDocsPage = document.querySelectorAll(`#anchor--${storyContext.id}`);
 
   const urls = () => {
-    if (window.location.href.startsWith('https://solid-design-system.github.io/solid')) {
-      const url = window.location.href;
-      const urlParts = url.split('/');
+    const baseUrl = 'https://solid-design-system.fe.union-investment.de';
+    const githubBaseUrl = 'https://solid-design-system.github.io/solid';
+    const cdnBaseUrl = 'https://cdn.jsdelivr.net/npm/@solid-design-system';
+
+    if (window.location.href.startsWith(githubBaseUrl)) {
+      const urlParts = window.location.href.split('/');
       const version = urlParts[urlParts.length - 2];
+
       if (version === 'next') {
         return {
-          components: `https://cdn.jsdelivr.net/npm/@solid-design-system/components@%COMPONENTS-VERSION%/cdn`,
-          styles: `https://cdn.jsdelivr.net/npm/@solid-design-system/styles@%STYLES-VERSION%/cdn`
-        };
-      } else if (version === 'main') {
-        return {
-          components: 'https://solid-design-system.fe.union-investment.de/components/%COMPONENTS-VERSION%',
-          styles: 'https://solid-design-system.fe.union-investment.de/styles/%STYLES-VERSION%'
-        };
-      } else {
-        return {
-          components: `https://solid-design-system.github.io/solid/${version}/components/cdn`,
-          styles: `https://solid-design-system.github.io/solid/${version}/styles/cdn`
+          components: `${cdnBaseUrl}/components@%COMPONENTS-VERSION%/cdn`,
+          styles: `${cdnBaseUrl}/styles@%STYLES-VERSION%/cdn`
         };
       }
-    } else {
+
+      if (version === 'main') {
+        return {
+          components: `${baseUrl}/components/%COMPONENTS-VERSION%/cdn`,
+          styles: `${baseUrl}/styles/%STYLES-VERSION%/cdn`
+        };
+      }
+
       return {
-        components: 'https://solid-design-system.fe.union-investment.de/components/%COMPONENTS-VERSION%',
-        styles: 'https://solid-design-system.fe.union-investment.de/styles/%STYLES-VERSION%'
+        components: `${githubBaseUrl}/${version}/components/cdn`,
+        styles: `${githubBaseUrl}/${version}/styles/cdn`
       };
     }
+
+    return {
+      components: `${baseUrl}/components/%COMPONENTS-VERSION%/cdn`,
+      styles: `${baseUrl}/styles/%STYLES-VERSION%/cdn`
+    };
   };
 
   // Unfortunately, the editable story in a docs page has the same ID as the first story.


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
This PR fixes the urls in `docs-codepen-enhancer` so that the correct files are loaded within the Codepen editor.
It also includes a small refactor of the urls logic to improve readability.

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
