### PR TITLE
fix: tags selected translation

### DIFF
--- a/.changeset/plenty-tigers-begin.md
+++ b/.changeset/plenty-tigers-begin.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/components': patch
+---
+
+Make the attribute `maxOptionsTagLabel` of the `sd-select` and `sd-combobox` components reactive to translations.

--- a/packages/components/src/components/combobox/combobox.test.ts
+++ b/packages/components/src/components/combobox/combobox.test.ts
@@ -1329,4 +1329,22 @@ describe('<sd-combobox>', () => {
 
     expect(placeholder.getAttribute('placeholder')).to.equal('Bitte suchen und auswählen');
   });
+
+  it('should display translated amount of selected tags', async () => {
+    const el = await fixture<SdSelect>(html`
+      <sd-combobox lang="de" multiple="" useTags value="option-1 option-2 option-3 option-4">
+        <sd-option value="option-1">Option 1</sd-option>
+        <sd-option value="option-2">Option 2</sd-option>
+        <sd-option value="option-3">Option 3</sd-option>
+        <sd-option value="option-4">Option 4</sd-option>
+        <sd-option value="option-5">Option 5</sd-option>
+      </sd-combobox>
+    `);
+
+    const tags = el.shadowRoot!.querySelector('[part~="tag"]')!;
+
+    await el.updateComplete;
+
+    expect(tags.textContent).to.equal('4 Optionen ausgewählt');
+  });
 });

--- a/packages/components/src/components/combobox/combobox.ts
+++ b/packages/components/src/components/combobox/combobox.ts
@@ -157,7 +157,7 @@ export default class SdCombobox extends SolidElement implements SolidFormControl
   @property() placeholder = '';
 
   /** Label text shown on tag if max-options-visible is reached. */
-  @property({ attribute: 'max-options-tag-label' }) maxOptionsTagLabel = this.localize.term('tagsSelected');
+  @property({ attribute: 'max-options-tag-label' }) maxOptionsTagLabel = '';
 
   /** Disables the combobox control. */
   @property({ reflect: true, type: Boolean }) disabled = false;
@@ -347,7 +347,7 @@ export default class SdCombobox extends SolidElement implements SolidFormControl
             removable
             @keydown=${(event: KeyboardEvent) => this.handleTagMaxOptionsKeyDown(event)}
             @sd-remove=${(event: CustomEvent) => this.handleTagRemove(event)}
-            >${this.selectedOptions.length} ${this.maxOptionsTagLabel}</sd-tag
+            >${this.selectedOptions.length} ${this.localize.term('tagsSelected')}</sd-tag
           >
         `
       ];

--- a/packages/components/src/components/select/select.test.ts
+++ b/packages/components/src/components/select/select.test.ts
@@ -655,4 +655,22 @@ describe('<sd-select>', () => {
     expect(placeholder.getAttribute('placeholder')).to.equal('Bitte auswählen');
     expect(clearButton.getAttribute('aria-label')).to.equal('Eingabe löschen');
   });
+
+  it('should display translated amount of selected tags', async () => {
+    const el = await fixture<SdSelect>(html`
+      <sd-select lang="de" value="option-1 option-2 option-3 option-4" useTags multiple="">
+        <sd-option value="option-1">Option 1</sd-option>
+        <sd-option value="option-2">Option 2</sd-option>
+        <sd-option value="option-3">Option 3</sd-option>
+        <sd-option value="option-4">Option 4</sd-option>
+        <sd-option value="option-5">Option 5</sd-option>
+      </sd-select>
+    `);
+
+    const tags = el.shadowRoot!.querySelector('[part~="tag"]')!;
+
+    await el.updateComplete;
+
+    expect(tags.textContent).to.equal('4 Optionen ausgewählt');
+  });
 });

--- a/packages/components/src/components/select/select.ts
+++ b/packages/components/src/components/select/select.ts
@@ -137,7 +137,7 @@ export default class SdSelect extends SolidElement implements SolidFormControl {
   @property() placeholder = '';
 
   /** Label text shown on tag if max-options-visible is reached. */
-  @property({ attribute: 'max-options-tag-label' }) maxOptionsTagLabel = this.localize.term('tagsSelected');
+  @property({ attribute: 'max-options-tag-label' }) maxOptionsTagLabel = '';
 
   /** Disables the select control. */
   @property({ type: Boolean, reflect: true }) disabled = false;
@@ -697,7 +697,7 @@ export default class SdSelect extends SolidElement implements SolidFormControl {
             removable
             @keydown=${(event: KeyboardEvent) => this.handleTagMaxOptionsKeyDown(event)}
             @sd-remove=${(event: CustomEvent) => this.handleTagRemove(event)}
-            >${this.selectedOptions.length} ${this.maxOptionsTagLabel}</sd-tag
+            >${this.selectedOptions.length} ${this.localize.term('tagsSelected')}</sd-tag
           >
         `
       ];


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
This PR adds reactive translation to the `maxOptionsTagLabel` attribute of the `sd-select` and `sd-combobox` components.

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
