### PR TITLE
fix: cherry pick sd-select and sd-combobox

### DIFF
--- a/.changeset/polite-laws-doubt.md
+++ b/.changeset/polite-laws-doubt.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/components': patch
+---
+
+Fixed issue with cherry picking the `sd-select` and `sd-combobox` components which required an empty chunk file.

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -106,6 +106,7 @@
     "globby": "^14.0.2",
     "gzip-size": "^7.0.0",
     "jsonata": "^2.0.6",
+    "lit-html": "^3.2.1",
     "minify-html-literals": "^1.3.5",
     "ora": "^8.1.1",
     "playwright": "^1.49.1",

--- a/packages/components/src/components/combobox/combobox.ts
+++ b/packages/components/src/components/combobox/combobox.ts
@@ -10,7 +10,7 @@ import { HasSlotController } from '../../internal/slot.js';
 import { LocalizeController } from '../../utilities/localize.js';
 import { property, query, state } from 'lit/decorators.js';
 import { scrollIntoView } from '../../internal/scroll.js';
-import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { waitForEvent } from '../../internal/event.js';
 import { watch } from '../../internal/watch.js';
 import cx from 'classix';

--- a/packages/components/src/components/select/select.ts
+++ b/packages/components/src/components/select/select.ts
@@ -8,7 +8,7 @@ import { HasSlotController } from '../../internal/slot.js';
 import { LocalizeController } from '../../utilities/localize.js';
 import { property, query, queryAssignedElements, state } from 'lit/decorators.js';
 import { scrollIntoView } from '../../internal/scroll.js';
-import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { waitForEvent } from '../../internal/event.js';
 import { watch } from '../../internal/watch.js';
 import cx from 'classix';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,9 @@ importers:
       jsonata:
         specifier: ^2.0.6
         version: 2.0.6
+      lit-html:
+        specifier: ^3.2.1
+        version: 3.2.1
       minify-html-literals:
         specifier: ^1.3.5
         version: 1.3.5


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
This PR addresses an issue where cherry-picking the `sd-select` and `sd-combobox` components fails due to an empty chunk file being required. The lit directive `unsafeHTML` when compiled generates this file. To overcome this issue, the directive is instead imported from the lit-html package.

The issue can be reproduced in this codepen: https://codepen.io/fzim/pen/dPbgpor

Screenshots of the build metadata:

<img width="797" alt="Screenshot 2025-01-23 at 12 40 43" src="https://github.com/user-attachments/assets/b89ba59a-6deb-4446-8944-6787cb718154" />
<img width="435" alt="Screenshot 2025-01-23 at 12 41 05" src="https://github.com/user-attachments/assets/120bd48b-f658-47c1-ad1b-266b8e1e719e" />


## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
