### PR TITLE
fix: sd-radio circle appearance when checked

### DIFF
--- a/.changeset/hip-paws-help.md
+++ b/.changeset/hip-paws-help.md
@@ -1,0 +1,7 @@
+---
+'@solid-design-system/components': patch
+---
+
+Improve sd-radio when checked:
+
+- Removed the inner border of the green circle to maintain consistency with Figma

--- a/packages/components/src/components/radio/radio.ts
+++ b/packages/components/src/components/radio/radio.ts
@@ -134,7 +134,7 @@ export default class SdRadio extends SolidElement {
                 <span
                   part="checked"
                   class=${cx(
-                    'rounded-full inline-flex text-white border bg-accent h-2.5 w-2.5',
+                    'rounded-full inline-flex text-white bg-accent h-2.5 w-2.5',
                     this.disabled
                       ? 'bg-neutral-500'
                       : this.invalid


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
Closes https://github.com/solid-design-system/solid/issues/1538

Changes: Removed border to improve appearance when checked:
before
![Image](https://github.com/user-attachments/assets/48b9207d-dcb7-42a0-aa2f-40ce56e6c51d)

after
- green circle 10x10
- outline green circle 16x16
- outline line is 1 and should be placed inside of the 16x16
![Image](https://github.com/user-attachments/assets/be3e6e23-57a9-4c04-b810-5390e8c3b94f)

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [x] relevant tickets are linked
