### PR TITLE
feat: add sd-status-badge

### DIFF
--- a/.changeset/chilly-nails-judge.md
+++ b/.changeset/chilly-nails-judge.md
@@ -1,0 +1,7 @@
+---
+'@solid-design-system/components': minor
+---
+
+Introduce new `sd-status-assets` icon library, to be used exclusively by the `sd-status-badge` style component.
+
+The new icons can be seen [here](https://solid-design-system.fe.union-investment.de/docs/?path=/story/components-sd-icon-default--status-library).

--- a/.changeset/small-snails-speak.md
+++ b/.changeset/small-snails-speak.md
@@ -1,0 +1,13 @@
+---
+'@solid-design-system/styles': minor
+---
+
+Add new `sd-status-badge` style component.
+
+This component can be used with the following variants:
+- `sd-status-badge--success`
+- `sd-status-badge--warning`
+- `sd-status-badge--error`
+- `sd-status-badge--info`
+
+The icons used together with this style component should come exclusively from the `sd-status-assets` library.

--- a/.changeset/strange-bobcats-do.md
+++ b/.changeset/strange-bobcats-do.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/docs': minor
+---
+
+Add the new style component `sd-status-badge` and a new status icon library (`sd-status-assets`) for exclusive use of this component.

--- a/packages/components/src/components/icon/library.status.ts
+++ b/packages/components/src/components/icon/library.status.ts
@@ -1,0 +1,58 @@
+import type { IconLibrary } from './library';
+
+//
+// Status icons are a separate library to ensure they're always available, regardless of how the default icon library is
+// configured or if its icons resolve properly.
+//
+// This library is for exclusive use with the `sd-status-badge` component.
+//
+export const icons = {
+  'status-check': `
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 12 12">
+      <path d="M9.202 2.228a.832.832 0 0 0-1.14.274v.003L5.006 7.691 3.542 6.23a.834.834 0 0 0-1.178 1.178L4.586 9.63a.83.83 0 0 0 .579.258h.107a.836.836 0 0 0 .609-.399l.002-.004 3.611-6.11a.833.833 0 0 0-.287-1.145l-.005-.002Z"/>
+    </svg>
+  `,
+  'status-exclamation': `
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 12 12">
+      <path d="M6.833 10.167a.834.834 0 1 1-1.667 0 .834.834 0 0 1 1.667 0ZM6 1a.834.834 0 0 0-.833.833v5a.834.834 0 0 0 1.666 0v-5A.834.834 0 0 0 6 1Z"/>
+    </svg>
+  `,
+  'status-close': `
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 12 12">
+      <path d="M9.645 2.355a.834.834 0 0 0-1.178 0L6 4.822 3.533 2.355a.834.834 0 0 0-1.178 1.178L4.823 6 2.355 8.466a.834.834 0 0 0 1.178 1.178L6 7.179l2.467 2.467a.834.834 0 0 0 1.178-1.178L7.178 6l2.467-2.467a.83.83 0 0 0 0-1.178Z"/>
+    </svg>
+  `,
+  'status-info': `
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 12 12">
+      <path d="M5.862 3.927A1.244 1.244 0 1 0 5.86 1.44a1.244 1.244 0 0 0 0 2.488Zm.968 1.935A.83.83 0 0 0 6 5.033h-.829a.83.83 0 0 0 0 1.658v2.21h-.83a.83.83 0 0 0 0 1.659h3.317a.83.83 0 0 0 0-1.658H6.83v-3.04Z"/>
+    </svg>
+  `,
+  'status-clock': `
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 12 12">
+      <path d="M6.01 5.656v-3.99a.834.834 0 0 0-1.667 0V6c0 .058.006.115.018.17l-.001-.006c.007.03.015.054.024.078l-.002-.005c0 .027 0 .056.025.083a.59.59 0 0 0 .046.086l-.001-.003.03.059c.034.047.068.089.106.127l3.356 3.359a.835.835 0 0 0 1.18-1.18L6.01 5.655Z"/>
+    </svg>
+  `,
+  'status-minus': `
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 12 12">
+      <path d="M9.76 5.333h-7.5A.834.834 0 0 0 2.26 7h7.5a.834.834 0 0 0 0-1.667Z"/>
+    </svg>
+  `,
+  'status-questionmark': `
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 12 12">
+      <path d="M6.843 10.167a.834.834 0 1 1-1.667 0 .834.834 0 0 1 1.667 0ZM6.01 1a2.777 2.777 0 0 0-2.778 2.777.834.834 0 0 0 1.667 0 1.111 1.111 0 0 1 2.222 0c0 .24-.517.792-.834 1.111-.555.586-1.11 1.192-1.11 1.944v.015a.834.834 0 0 0 1.666.014c.196-.316.416-.59.666-.833.6-.64 1.278-1.362 1.278-2.262A2.777 2.777 0 0 0 6.01 1Z"/>
+    </svg>
+  `
+};
+
+const statusLibrary: IconLibrary = {
+  name: 'sd-status-assets',
+  resolver: (name: keyof typeof icons) => {
+    if (name in icons) {
+      return `data:image/svg+xml,${encodeURIComponent(icons[name])}`;
+    }
+    return '';
+  },
+  mutator: svg => svg.setAttribute('fill', 'currentColor')
+};
+
+export default statusLibrary;

--- a/packages/components/src/components/icon/library.ts
+++ b/packages/components/src/components/icon/library.ts
@@ -1,4 +1,5 @@
 import defaultLibrary from './library.default';
+import statusLibrary from './library.status';
 import systemLibrary from './library.system';
 import type SdIcon from '../icon/icon';
 
@@ -10,7 +11,7 @@ export interface IconLibrary {
   mutator?: IconLibraryMutator;
 }
 
-let registry: IconLibrary[] = [systemLibrary, defaultLibrary];
+let registry: IconLibrary[] = [systemLibrary, defaultLibrary, statusLibrary];
 let watchedIcons: SdIcon[] = [];
 
 /** Adds an icon to the list of watched icons. */

--- a/packages/docs/src/stories/components/icon.default.stories.ts
+++ b/packages/docs/src/stories/components/icon.default.stories.ts
@@ -78,3 +78,34 @@ export const LibraryDefaultSystem = {
       args
     })
 };
+
+export const StatusLibrary = {
+  name: 'sd-status-assets',
+  render: (args: any) =>
+    generateTemplate({
+      axis: {
+        x: {
+          type: 'attribute',
+          name: 'color'
+        },
+        y: {
+          type: 'attribute',
+          name: 'name',
+          values: [
+            'status-check',
+            'status-exclamation',
+            'status-close',
+            'status-info',
+            'status-clock',
+            'status-minus',
+            'status-questionmark'
+          ]
+        }
+      },
+      constants: [{ type: 'attribute', name: 'library', value: 'sd-status-assets' }],
+      options: {
+        templateBackgrounds: { alternate: 'x', colors: ['white', 'white', 'rgb(var(--sd-color-primary, 0 53 142))'] }
+      },
+      args
+    })
+};

--- a/packages/docs/src/stories/styles/status-badge.stories.ts
+++ b/packages/docs/src/stories/styles/status-badge.stories.ts
@@ -1,0 +1,74 @@
+import { html } from 'lit-html';
+import { storybookDefaults, storybookHelpers, storybookTemplate } from '../../../scripts/storybook/helper';
+import { withActions } from '@storybook/addon-actions/decorator';
+
+const { argTypes, args, parameters } = storybookDefaults('sd-status-badge');
+const { overrideArgs } = storybookHelpers('sd-status-badge');
+const { generateTemplate } = storybookTemplate('sd-status-badge');
+
+/**
+ * Used as a visual, non-interactive indicator of a status related to a particular element.
+ */
+
+export default {
+  title: 'Styles/sd-status-badge',
+  tags: ['!dev'],
+  component: 'sd-status-badge',
+  args: overrideArgs([
+    {
+      type: 'slot',
+      name: 'default',
+      value: `<sd-icon name="status-check" library="sd-status-assets"></sd-icon>
+        Active`
+    },
+    { type: 'attribute', name: 'class', value: 'sd-status-badge--success' }
+  ]),
+  argTypes,
+  parameters: {
+    ...parameters,
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/VTztxQ5pWG7ARg8hCX6PfR/Solid-DS-%E2%80%93-Component-Library?node-id=18391-37775&t=LaSTkqB8MKXGCZbc-0'
+    }
+  },
+  decorators: [withActions] as any
+};
+
+export const Default = {
+  render: (args: any) => {
+    return generateTemplate({
+      options: { templateContent: '<div class="%CLASSES%">%SLOT%</div>' },
+      args
+    });
+  }
+};
+
+/**
+ * Use the `sd-status-badge` classes for alternative appearances:
+ * - `sd-status-badge--success`
+ * - `sd-status-badge--warning`
+ * - `sd-status-badge--error`
+ * - `sd-status-badge--info`
+ */
+export const Variants = {
+  render: () => {
+    return html`<div class="flex flex-col items-start gap-4">
+      <div class="sd-status-badge sd-status-badge--success">
+        <sd-icon name="status-check" library="sd-status-assets"></sd-icon>
+        Active
+      </div>
+      <div class="sd-status-badge sd-status-badge--warning">
+        <sd-icon name="status-exclamation" library="sd-status-assets"></sd-icon>
+        Degraded
+      </div>
+      <div class="sd-status-badge sd-status-badge--error">
+        <sd-icon name="status-close" library="sd-status-assets"></sd-icon>
+        Canceled
+      </div>
+      <div class="sd-status-badge sd-status-badge--info">
+        <sd-icon name="status-info" library="sd-status-assets"></sd-icon>
+        Status Info
+      </div>
+    </div>`;
+  }
+};

--- a/packages/docs/src/stories/styles/status-badge.test.stories.ts
+++ b/packages/docs/src/stories/styles/status-badge.test.stories.ts
@@ -1,0 +1,76 @@
+import { html } from 'lit-html';
+import {
+  storybookDefaults,
+  storybookHelpers,
+  storybookTemplate,
+  storybookUtilities
+} from '../../../scripts/storybook/helper';
+import { withActions } from '@storybook/addon-actions/decorator';
+
+const { argTypes, parameters } = storybookDefaults('sd-status-badge');
+const { overrideArgs } = storybookHelpers('sd-status-badge');
+const { generateTemplate } = storybookTemplate('sd-status-badge');
+const { generateScreenshotStory } = storybookUtilities;
+
+/**
+ *
+ * Component description.
+ *
+ */
+
+export default {
+  title: 'Styles/sd-status-badge/Screenshots: sd-status-badge',
+  tags: ['!autodocs'],
+  component: 'sd-status-badge',
+  parameters: {
+    ...parameters,
+    controls: { disable: true },
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/VTztxQ5pWG7ARg8hCX6PfR/Solid-DS-%E2%80%93-Component-Library?node-id=18391-37775&t=LaSTkqB8MKXGCZbc-0'
+    }
+  },
+  args: overrideArgs([
+    {
+      type: 'slot',
+      name: 'default',
+      value: `<sd-icon name="status-check" library="sd-status-assets"></sd-icon>
+        Active`
+    },
+    { type: 'attribute', name: 'class', value: 'sd-status-badge--success' }
+  ]),
+  argTypes,
+  decorators: [withActions] as any
+};
+
+export const Default = {
+  name: 'Default',
+  render: (args: any) => {
+    return generateTemplate({ args });
+  }
+};
+
+export const Variants = {
+  name: 'Variants',
+  render: (args: any) => {
+    return generateTemplate({
+      axis: {
+        y: [
+          {
+            type: 'attribute',
+            name: 'sd-status-badge--variant',
+            values: [
+              'sd-status-badge--success',
+              'sd-status-badge--warning',
+              'sd-status-badge--error',
+              'sd-status-badge--info'
+            ]
+          }
+        ]
+      },
+      args
+    });
+  }
+};
+
+export const Combination = generateScreenshotStory([Default, Variants]);

--- a/packages/styles/src/modules/status-badge.css
+++ b/packages/styles/src/modules/status-badge.css
@@ -1,0 +1,39 @@
+/**
+ * Description of the style.
+ * @name sd-status-badge
+ * @status stable
+ * @since 1.0
+ * @variant { sucess | warning | error | info } sd-status-badge--...
+ */
+
+.sd-status-badge {
+  @apply inline-flex items-center justify-center;
+
+  sd-icon {
+    @apply flex rounded-full h-3 w-3 text-white mr-2 p-1;
+  }
+
+  &--success {
+    sd-icon {
+      @apply bg-success;
+    }
+  }
+
+  &--warning {
+    sd-icon {
+      @apply bg-warning;
+    }
+  }
+
+  &--error {
+    sd-icon {
+      @apply bg-error;
+    }
+  }
+
+  &--info {
+    sd-icon {
+      @apply bg-info;
+    }
+  }
+}

--- a/packages/styles/src/solid-styles.css
+++ b/packages/styles/src/solid-styles.css
@@ -6,5 +6,6 @@
 @import url('./modules/hidden-links.css');
 @import url('./modules/mark.css');
 @import url('./modules/meta.css');
+@import url('./modules/status-badge.css');
 /* plop:style */
 @import url('./modules/prose.css');


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
Introduces new style component `sd-status-badge` and icon library `sd-status-assets`.
Closes [#775 ](https://github.com/solid-design-system/solid/issues/775)

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
