### PR TITLE
fix: docs show code font-family

### DIFF
--- a/.changeset/six-bottles-allow.md
+++ b/.changeset/six-bottles-allow.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/docs': major
+---
+
+Fix monospace font-family on show code section.

--- a/packages/docs/.storybook/preview-head.html
+++ b/packages/docs/.storybook/preview-head.html
@@ -3,7 +3,7 @@
   document.documentElement.setAttribute('lang', 'en');
 </script>
 <style>
-  body * {
+  body *:not(pre .token) {
     font-family:
       'Frutiger Neue',
       ui-sans-serif,


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
<!-- *PR notes: Please describe the changes in this PR.* -->

When updating storybooks font-family to align with brands' font, it broke the monospaced font-family on the "Show code" sections.

This PR fixes that regression.

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
