### PR TITLE
fix: dialog height

### DIFF
--- a/.changeset/beige-glasses-glow.md
+++ b/.changeset/beige-glasses-glow.md
@@ -1,0 +1,10 @@
+---
+'@solid-design-system/components': patch
+---
+
+Fixed the following issues in `sd-dialog`:
+
+- Panel max-height is set to 80vh.
+- On higher zoom levels (e.g. 400%):
+  - Panel body now has a min-height to prevent collapsing.
+  - Added `overflow-y: auto` to the footer to prevent.

--- a/.changeset/beige-glasses-glow.md
+++ b/.changeset/beige-glasses-glow.md
@@ -7,4 +7,4 @@ Fixed the following issues in `sd-dialog`:
 - Panel max-height is set to 80vh.
 - On higher zoom levels (e.g. 400%):
   - Panel body now has a min-height to prevent collapsing.
-  - Added `overflow-y: auto` to the footer to prevent.
+  - Added `overflow-y: auto` to the footer to prevent content from overflowing.

--- a/packages/components/src/components/dialog/dialog.ts
+++ b/packages/components/src/components/dialog/dialog.ts
@@ -265,7 +265,7 @@ export default class SdDialog extends SolidElement {
         <div
           part="panel"
           class=${cx(
-            'flex flex-col z-20 bg-white py-4 sm:py-8 relative gap-6 focus-visible:focus-outline-inverted',
+            'flex flex-col z-20 bg-white py-4 sm:py-8 relative gap-6 focus-visible:focus-outline-inverted overflow-y-auto',
             this.open && 'flex opacity-100'
           )}
           role="dialog"
@@ -335,6 +335,11 @@ export default class SdDialog extends SolidElement {
         :host {
           --width: 335px;
         }
+
+        [part='body'] {
+          min-height: 50px;
+        }
+
         [part='footer'] {
           @apply w-full;
         }

--- a/packages/components/src/components/dialog/dialog.ts
+++ b/packages/components/src/components/dialog/dialog.ts
@@ -324,6 +324,7 @@ export default class SdDialog extends SolidElement {
 
       [part='panel'] {
         width: var(--width);
+        max-height: 80vh;
       }
 
       [part='body'] {


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
This PR sets the dialog panel max-height and prevents panel elements from collapsing or overflowing when the component is displayed in high zoom level (400%).

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
