### PR TITLE
fix: sd-audio a11y

### DIFF
--- a/.changeset/long-balloons-study.md
+++ b/.changeset/long-balloons-study.md
@@ -1,0 +1,8 @@
+---
+'@solid-design-system/components': patch
+---
+
+Improved `sd-audio` accessibility and fixed progress bar syncronization.
+
+- Corrently set aria attributes in the control buttons.
+- Used floating-points to more accurately set `currentTime`, `duration` and progress bar calculations.

--- a/.changeset/long-balloons-study.md
+++ b/.changeset/long-balloons-study.md
@@ -4,5 +4,5 @@
 
 Improved `sd-audio` accessibility and fixed progress bar syncronization.
 
-- Corrently set aria attributes in the control buttons.
+- Correctly set aria attributes in the control buttons.
 - Used floating-points to more accurately set `currentTime`, `duration` and progress bar calculations.

--- a/packages/components/src/components/audio/audio.test.ts
+++ b/packages/components/src/components/audio/audio.test.ts
@@ -89,4 +89,21 @@ describe('<sd-audio>', () => {
 
     expect(spy.calledOnce).to.be.true;
   });
+
+  it('should have the correct aria-labels', async () => {
+    const el = await fixture<SdAudio>(html`
+      <sd-audio>
+        <audio src="${base64Audio}"></audio>
+        <div slot="transcript">Transcript</div>
+      </sd-audio>
+    `);
+
+    const transcript = el.shadowRoot!.querySelector('[part="transcript"]')!;
+    const playButton = el.shadowRoot!.querySelector('[part="play-button"]')!;
+    const volumeButton = el.shadowRoot!.querySelector('[part="volume"]')!;
+
+    expect(transcript.getAttribute('aria-label')).to.equal('Open transcript');
+    expect(playButton.getAttribute('aria-label')).to.equal('Play Audio');
+    expect(volumeButton.getAttribute('aria-label')).to.equal('Mute');
+  });
 });

--- a/packages/components/src/components/audio/audio.ts
+++ b/packages/components/src/components/audio/audio.ts
@@ -65,6 +65,8 @@ export default class SdAudio extends SolidElement {
 
   @state() isMuted: boolean = false;
 
+  @state() isTranscriptOpen: boolean = false;
+
   @state() progress: number = 0;
 
   @query('[part="progress-slider"]') progressSlider: HTMLInputElement;
@@ -85,6 +87,7 @@ export default class SdAudio extends SolidElement {
     this.handleAudioEnd = this.handleAudioEnd.bind(this);
     this.handleAudioProgress = this.handleAudioProgress.bind(this);
     this.handleAudioProgressKeydown = this.handleAudioProgressKeydown.bind(this);
+    this.handleTranscriptDrawer = this.handleTranscriptDrawer.bind(this);
   }
 
   firstUpdated() {
@@ -93,6 +96,7 @@ export default class SdAudio extends SolidElement {
     this.audioElement.addEventListener('timeupdate', this.updateCurrentTime);
     this.audioElement.addEventListener('ended', this.handleAudioEnd);
     this.audioElement.setAttribute('controlsList', 'nodownload');
+    document.addEventListener('sd-after-hide', this.handleTranscriptDrawer);
     this.audioElement.playbackRate = this.speed;
 
     if (this.animated) {
@@ -251,9 +255,14 @@ export default class SdAudio extends SolidElement {
     }
   }
 
+  private handleTranscriptDrawer() {
+    this.isTranscriptOpen = !this.isTranscriptOpen;
+  }
+
   private showTranscript() {
     this.emit('sd-transcript-click');
     this.drawer.open = true;
+    this.handleTranscriptDrawer();
   }
 
   private showTranscriptKeydown(event: KeyboardEvent): void {
@@ -429,16 +438,14 @@ export default class SdAudio extends SolidElement {
                 'mr-6 w-6 h-6 hover:cursor-pointer sd-interactive',
                 this.inverted && 'sd-interactive--inverted'
               )}
+              aria-label=${this.isTranscriptOpen
+                ? this.localize.term('transcriptIsOpen')
+                : this.localize.term('openTranscript')}
               @click=${this.showTranscript}
               @keydown=${this.showTranscriptKeydown}
               tab-index="0"
             >
-              <sd-icon
-                class="w-6 h-6"
-                name="transcript"
-                library="system"
-                label=${this.isMuted ? this.localize.term('unmute') : this.localize.term('mute')}
-              ></sd-icon>
+              <sd-icon class="w-6 h-6" name="transcript" library="system"></sd-icon>
             </button>`
           : null}
 

--- a/packages/components/src/components/audio/audio.ts
+++ b/packages/components/src/components/audio/audio.ts
@@ -501,6 +501,7 @@ export default class SdAudio extends SolidElement {
             tabindex="0"
             @input=${this.handleAudioProgress}
             @keydown=${this.handleAudioProgressKeydown}
+            aria-label=${this.localize.term('seekBar')}
             part="progress-slider"
             style="background: linear-gradient(to right,
               ${this.inverted

--- a/packages/components/src/components/audio/audio.ts
+++ b/packages/components/src/components/audio/audio.ts
@@ -87,7 +87,7 @@ export default class SdAudio extends SolidElement {
     this.handleAudioEnd = this.handleAudioEnd.bind(this);
     this.handleAudioProgress = this.handleAudioProgress.bind(this);
     this.handleAudioProgressKeydown = this.handleAudioProgressKeydown.bind(this);
-    this.handleTranscriptDrawer = this.handleTranscriptDrawer.bind(this);
+    this.handleTranscriptDrawerToggle = this.handleTranscriptDrawerToggle.bind(this);
   }
 
   firstUpdated() {
@@ -96,7 +96,7 @@ export default class SdAudio extends SolidElement {
     this.audioElement.addEventListener('timeupdate', this.updateCurrentTime);
     this.audioElement.addEventListener('ended', this.handleAudioEnd);
     this.audioElement.setAttribute('controlsList', 'nodownload');
-    document.addEventListener('sd-after-hide', this.handleTranscriptDrawer);
+    document.addEventListener('sd-after-hide', this.handleTranscriptDrawerToggle);
     this.audioElement.playbackRate = this.speed;
 
     if (this.animated) {
@@ -258,7 +258,7 @@ export default class SdAudio extends SolidElement {
   private showTranscript() {
     this.emit('sd-transcript-click');
     this.drawer.open = true;
-    this.handleTranscriptDrawer();
+    this.handleTranscriptDrawerToggle();
   }
 
   private showTranscriptKeydown(event: KeyboardEvent): void {

--- a/packages/components/src/components/audio/audio.ts
+++ b/packages/components/src/components/audio/audio.ts
@@ -441,6 +441,7 @@ export default class SdAudio extends SolidElement {
               @click=${this.showTranscript}
               @keydown=${this.showTranscriptKeydown}
               tab-index="0"
+              part="transcript"
             >
               <sd-icon class="w-6 h-6" name="transcript" library="system"></sd-icon>
             </button>`

--- a/packages/components/src/components/audio/audio.ts
+++ b/packages/components/src/components/audio/audio.ts
@@ -251,7 +251,7 @@ export default class SdAudio extends SolidElement {
     }
   }
 
-  private handleTranscriptDrawer() {
+  private handleTranscriptDrawerToggle() {
     this.isTranscriptOpen = !this.isTranscriptOpen;
   }
 

--- a/packages/components/src/components/audio/audio.ts
+++ b/packages/components/src/components/audio/audio.ts
@@ -452,7 +452,7 @@ export default class SdAudio extends SolidElement {
         <button
           class=${cx('w-6 h-6 hover:cursor-pointer sd-interactive', this.inverted && 'sd-interactive--inverted')}
           part="volume"
-          aria-label=${this.localize.term('mute')}
+          aria-label=${!this.isMuted ? this.localize.term('mute') : this.localize.term('unmute')}
           tabindex="0"
           @click=${this.toggleMute}
           @keydown=${this.toggleMuteKeydown}

--- a/packages/components/src/components/audio/audio.ts
+++ b/packages/components/src/components/audio/audio.ts
@@ -420,6 +420,7 @@ export default class SdAudio extends SolidElement {
         size="lg"
         @click=${!this.isPlaying ? this.playAudio : this.pauseAudio}
         aria-label="${this.isPlaying ? this.localize.term('pauseAudio') : this.localize.term('playAudio')}"
+        title="${this.isPlaying ? this.localize.term('pauseAudio') : this.localize.term('playAudio')}"
         class="text-3xl"
       >
         ${this.isPlaying

--- a/packages/components/src/components/audio/audio.ts
+++ b/packages/components/src/components/audio/audio.ts
@@ -124,16 +124,12 @@ export default class SdAudio extends SolidElement {
     return null;
   }
 
-  private setAudioProgress = () => {
-    this.progressSlider.max = Math.floor(this.audioElement!.duration).toString();
-  };
-
   private updateCurrentTime() {
     if (!this.audioElement) return;
 
     const currentTime = this.audioElement.currentTime;
     this.currentTime = this.formatTime(currentTime);
-    this.progress = Math.floor(currentTime);
+    this.progress = currentTime;
 
     if (this.progressSlider) {
       this.progressSlider.value = this.progress.toString();
@@ -152,7 +148,7 @@ export default class SdAudio extends SolidElement {
     }
 
     this.duration = this.formatTime(this.audioElement.duration);
-    this.setAudioProgress();
+    this.progressSlider.max = this.audioElement.duration.toString();
   }
 
   playAudio() {

--- a/packages/components/src/translations/de.ts
+++ b/packages/components/src/translations/de.ts
@@ -25,6 +25,7 @@ const translation: Translation = {
     if (num === 0) return '';
     return `Optionen ausgewählt (${num})`;
   },
+  openTranscript: 'Abschrift öffnen',
   pauseAudio: 'Audio pausieren',
   playAudio: 'Audio abspielen',
   playbackSpeed: 'Wiedergabe Geschwindigkeit',
@@ -34,6 +35,7 @@ const translation: Translation = {
   removed: name => `${name} entfernt`,
   resize: 'Größe ändern',
   scrollToEnd: 'Zum Ende scrollen',
+  seekBar: 'Bar suchen',
   scrollToStart: 'Zum Anfang scrollen',
   selectAColorFromTheScreen: 'Farbe vom Bildschirm auswählen',
   selectDefaultPlaceholder: 'Bitte auswählen',
@@ -43,6 +45,7 @@ const translation: Translation = {
   slideNum: (slide, count) => `Folie ${slide} von ${count}`,
   tagsSelected: 'Optionen ausgewählt',
   toggleColorFormat: 'Farbformat umschalten',
+  transcriptIsOpen: 'Abschrift ist offen',
   unmute: 'Unmute'
 };
 

--- a/packages/components/src/translations/en.ts
+++ b/packages/components/src/translations/en.ts
@@ -36,6 +36,7 @@ const translation: Translation = {
   resize: 'Resize',
   scrollToEnd: 'Scroll to end',
   scrollToStart: 'Scroll to start',
+  seekBar: 'Seek bar',
   selectAColorFromTheScreen: 'Select a color from the screen',
   selectDefaultPlaceholder: 'Please select',
   showLess: 'Show less',

--- a/packages/components/src/translations/en.ts
+++ b/packages/components/src/translations/en.ts
@@ -25,6 +25,7 @@ const translation: Translation = {
     if (num === 0) return '';
     return `Options Selected (${num})`;
   },
+  openTranscript: 'Open transcript',
   pauseAudio: 'Pause Audio',
   playAudio: 'Play Audio',
   playbackSpeed: 'Playback Speed',
@@ -43,6 +44,7 @@ const translation: Translation = {
   slideNum: num => `Slide ${num}`,
   tagsSelected: 'Options selected',
   toggleColorFormat: 'Toggle color format',
+  transcriptIsOpen: 'Transcript is open',
   unmute: 'Unmute'
 };
 

--- a/packages/components/src/utilities/localize.ts
+++ b/packages/components/src/utilities/localize.ts
@@ -90,6 +90,7 @@ export interface Translation extends DefaultTranslation {
   noResults: string;
   notifications: string;
   numOptionsSelected: (num: number) => string;
+  openTranscript: string;
   pauseAudio: string;
   playAudio: string;
   playbackSpeed: string;
@@ -108,5 +109,6 @@ export interface Translation extends DefaultTranslation {
   slideNum: (slide: number, count: number) => string;
   tagsSelected: string;
   toggleColorFormat: string;
+  transcriptIsOpen: string;
   unmute: string;
 }

--- a/packages/components/src/utilities/localize.ts
+++ b/packages/components/src/utilities/localize.ts
@@ -101,6 +101,7 @@ export interface Translation extends DefaultTranslation {
   resize: string;
   scrollToEnd: string;
   scrollToStart: string;
+  seekBar: string;
   selectAColorFromTheScreen: string;
   selectDefaultPlaceholder: string;
   showLess: string;


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
This PR addresses an issue with the progress bar syncronization, aria-attributes incorrectly set and also closes [#1869](https://github.com/solid-design-system/solid/issues/1869)

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
