### PR TITLE
chore: add release notes subtask template [skip chromatic]

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-notes-subtask-template.md
+++ b/.github/ISSUE_TEMPLATE/release-notes-subtask-template.md
@@ -12,7 +12,7 @@ In order to publish our release notes by the end of every iteration in MS Teams 
 
 ## ToDos
 - [ ] create the release notes in figma
-- [ ] create an publish the page in our communications repo
+- [ ] create and publish the page in our communications repo
   - [ ] create iteration page
   - [ ] update select filed with new option (latest iteration)
   - [ ] update all solid resources in the repo to the latest version

--- a/.github/ISSUE_TEMPLATE/release-notes-subtask-template.md
+++ b/.github/ISSUE_TEMPLATE/release-notes-subtask-template.md
@@ -15,7 +15,7 @@ In order to publish our release notes by the end of every iteration in MS Teams 
 - [ ] create and publish the page in our communications repo
   - [ ] create iteration page
   - [ ] update select field with new option (latest iteration)
-  - [ ] update all solid resources in the repo to the latest version
+  - [ ] update all solid CDN resources in the repo to the latest version
 - [ ] publish release notes in MS Teams (general channel)
 - [ ] publish release notes in UniVersum
 

--- a/.github/ISSUE_TEMPLATE/release-notes-subtask-template.md
+++ b/.github/ISSUE_TEMPLATE/release-notes-subtask-template.md
@@ -14,7 +14,7 @@ In order to publish our release notes by the end of every iteration in MS Teams 
 - [ ] create the release notes in figma
 - [ ] create and publish the page in our communications repo
   - [ ] create iteration page
-  - [ ] update select filed with new option (latest iteration)
+  - [ ] update select field with new option (latest iteration)
   - [ ] update all solid resources in the repo to the latest version
 - [ ] publish release notes in MS Teams (general channel)
 - [ ] publish release notes in UniVersum

--- a/.github/ISSUE_TEMPLATE/release-notes-subtask-template.md
+++ b/.github/ISSUE_TEMPLATE/release-notes-subtask-template.md
@@ -1,0 +1,30 @@
+---
+name: Release Notes Subtask
+about: Template to create a subtask for the release notes in each iteration.
+title: 'docs: 📚 create release notes for iteration #[NUMBER]'
+labels: 'docs, 🎨 figma, 🔧 code, Subtask'
+assignees: ''
+
+---
+
+## Description
+In order to publish our release notes by the end of every iteration in MS Teams and in UniVersum, they need to be created on our communications page.
+
+## ToDos
+- [ ] create the release notes in figma
+- [ ] create an publish the page in our communications repo
+  - [ ] create iteration page
+  - [ ] update select filed with new option (latest iteration)
+  - [ ] update all solid resources in the repo to the latest version
+- [ ] publish release notes in MS Teams (general channel)
+- [ ] publish release notes in UniVersum
+
+## DoR
+- [x] Item has business value
+- [ ] Item has been estimated by the team
+- [x] Item is clear and well-defined
+- [x] Item dependencies have been identified
+
+## DoD
+- [ ] Documentation has been created/updated (if applicable)
+- [ ] Implementation works successfully on `feature` branch

--- a/.github/ISSUE_TEMPLATE/release-notes-subtask-template.md
+++ b/.github/ISSUE_TEMPLATE/release-notes-subtask-template.md
@@ -2,7 +2,7 @@
 name: Release Notes Subtask
 about: Template to create a subtask for the release notes in each iteration.
 title: 'docs: 📚 create release notes for iteration #[NUMBER]'
-labels: 'docs, 🎨 figma, 🔧 code, Subtask'
+labels: 'documentation, 🎨 figma, 🔧 code, Subtask'
 assignees: ''
 
 ---


### PR DESCRIPTION
## Description:
added a new template to easily setup subtasks every iteration

new setup:
- #1923 will be the never-ending-parent-epic-task with 0 SP, assigned to @yoezlem and always "in progress"
- each iteration we create a new subtask with this template

this follows the way, our dependancy dashboard works but there we have a bot from renovate taking care of reopening it each time. 