### PR TITLE
fix: sd-combobox a11y

### DIFF
--- a/.changeset/curvy-buckets-buy.md
+++ b/.changeset/curvy-buckets-buy.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/docs': patch
+---
+
+Update `sd-combobox` screenshots tests and stories with missing labels to fix a11y issues.

--- a/packages/docs/src/stories/components/combobox.stories.ts
+++ b/packages/docs/src/stories/components/combobox.stories.ts
@@ -54,7 +54,7 @@ const createColorOptionsHtml = () => unsafeHTML(createColorOptions().join('\n'))
 
 export default {
   title: 'Components/sd-combobox',
-  tags: ['!dev', 'skip-a11y'],
+  tags: ['!dev'],
   component: 'sd-combobox',
   args: overrideArgs([
     threeOptionsConstant,
@@ -333,7 +333,7 @@ export const Clearable = {
 export const Icons = {
   render: () => html`
     <div class="w-[400px] h-[400px]">
-      <sd-combobox placeholder="Small" size="sm" clearable>
+      <sd-combobox placeholder="Small" size="sm" clearable label="Label">
         <sd-icon slot="left" name="system/image" aria-hidden="true" color="currentColor"></sd-icon>
         ${createColorOptionsHtml()}
         <button slot="right" aria-label="Search">
@@ -341,7 +341,7 @@ export const Icons = {
         </button>
       </sd-combobox>
       <br />
-      <sd-combobox placeholder="Medium" size="md" clearable>
+      <sd-combobox placeholder="Medium" size="md" clearable label="Label">
         <sd-icon slot="left" name="system/image" aria-hidden="true" color="currentColor"></sd-icon>
         ${createColorOptionsHtml()}
         <button slot="right" aria-label="Search">
@@ -349,7 +349,7 @@ export const Icons = {
         </button>
       </sd-combobox>
       <br />
-      <sd-combobox placeholder="Large" size="lg" clearable>
+      <sd-combobox placeholder="Large" size="lg" clearable label="Label">
         <sd-icon slot="left" name="system/image" aria-hidden="true" color="currentColor"></sd-icon>
         ${createColorOptionsHtml()}
         <button slot="right" aria-label="Search">

--- a/packages/docs/src/stories/components/combobox.stories.ts
+++ b/packages/docs/src/stories/components/combobox.stories.ts
@@ -59,7 +59,7 @@ export default {
   args: overrideArgs([
     threeOptionsConstant,
     labelConstant,
-    { type: 'attribute', name: 'placeholder', value: 'Please search and select' },
+    { type: 'attribute', name: 'placeholder', value: ' ' },
     { type: 'attribute', name: 'max-options-visible', value: 3 },
     { type: 'attribute', name: 'getOption', value: '' }
   ]),
@@ -328,28 +328,13 @@ export const Clearable = {
  *  Use the “left” and “right” slots to add system icons
  *  Show search icon in left either left or right icon slot with the chevron icon (don’t show 2 icons on the right hand side)
  *  Not showing the label here is only fine when showing search-icon.
+ *
  *  __Accessibility hint__: Label can be omitted for search input fields if a button (e.g., aria-label="Search") with a search icon is present.
  */
 export const Icons = {
   render: () => html`
     <div class="w-[400px] h-[400px]">
-      <sd-combobox placeholder="Small" size="sm" clearable label="Label">
-        <sd-icon slot="left" name="system/image" aria-hidden="true" color="currentColor"></sd-icon>
-        ${createColorOptionsHtml()}
-        <button slot="right" aria-label="Search">
-          <sd-icon library="system" name="magnifying-glass" aria-hidden="true" color="currentColor"></sd-icon>
-        </button>
-      </sd-combobox>
-      <br />
-      <sd-combobox placeholder="Medium" size="md" clearable label="Label">
-        <sd-icon slot="left" name="system/image" aria-hidden="true" color="currentColor"></sd-icon>
-        ${createColorOptionsHtml()}
-        <button slot="right" aria-label="Search">
-          <sd-icon library="system" name="magnifying-glass" aria-hidden="true" color="currentColor"></sd-icon>
-        </button>
-      </sd-combobox>
-      <br />
-      <sd-combobox placeholder="Large" size="lg" clearable label="Label">
+      <sd-combobox size="lg" clearable label="Large">
         <sd-icon slot="left" name="system/image" aria-hidden="true" color="currentColor"></sd-icon>
         ${createColorOptionsHtml()}
         <button slot="right" aria-label="Search">
@@ -365,6 +350,7 @@ export const Icons = {
  * To inform your users about their selected options tags are displayed.
  * Use Backspace to remove the last selected option.
  * Use `--tag-max-width` to set the maximum width of the tags and to show an ellipsis, e.g. `<sd-combobox style="--tag-max-width: 40px">`. The default value is `15ch`.
+ *
  * __Hint:__ If you really don't want to show tags, you can hide them with CSS via `::part(tags)`.
  */
 

--- a/packages/docs/src/stories/components/combobox.stories.ts
+++ b/packages/docs/src/stories/components/combobox.stories.ts
@@ -341,7 +341,7 @@ export const Clearable = {
 export const Icons = {
   render: () => html`
     <div class="w-[400px] h-[400px]">
-      <sd-combobox size="lg" clearable label="Large">
+      <sd-combobox size="lg" clearable label="Label">
         <sd-icon slot="left" name="system/image" aria-hidden="true" color="currentColor"></sd-icon>
         ${createColorOptionsHtml()}
         <button slot="right" aria-label="Search">

--- a/packages/docs/src/stories/components/combobox.test.stories.ts
+++ b/packages/docs/src/stories/components/combobox.test.stories.ts
@@ -73,7 +73,7 @@ const createColorOptionsHtml = () => unsafeHTML(createColorOptions().join('\n'))
 
 export default {
   title: 'Components/sd-combobox/Screenshots: sd-combobox',
-  tags: ['!autodocs', 'skip-a11y'],
+  tags: ['!autodocs'],
   component: 'sd-combobox',
   args: overrideArgs([
     threeOptionsConstant,
@@ -280,9 +280,10 @@ export const Slots = {
                   value:
                     slot === 'default'
                       ? `<sd-option></sd-option>`
-                      : `<div slot='${slot}' class="slot slot--border slot--background h-6 ${
-                          slot === 'label' || slot === 'help-text' ? 'w-20' : 'w-6'
-                        }"></div>`,
+                      : `<div
+                          slot='${slot}'
+                          class="slot slot--border slot--background h-6 ${slot === 'label' || slot === 'help-text' ? 'w-20' : 'w-6'}"
+                      >${slot === 'label' ? 'Label' : ''}</div>`,
                   title: slot
                 }
               ]
@@ -789,7 +790,7 @@ export const setCustomValidity = {
     return html`
       <!-- block submit and show alert instead -->
       <form id="validationForm" class="flex flex-col gap-2">
-        <sd-combobox id="custom-input" style-on-valid>
+        <sd-combobox id="custom-input" style-on-valid label="Label">
           <sd-option value="option-1">Option 1</sd-option>
           <sd-option value="option-2">Option 2</sd-option>
           <sd-option value="option-3">Option 3</sd-option>


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
Closes [#1875 ](https://github.com/solid-design-system/solid/issues/1875)

@MartaPintoTeixeira in the `icons` story I had to include labels. Please sync with Figma. Thank you

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
