### PR TITLE
fix: sd-optgroup a11y

### DIFF
--- a/.changeset/fruity-needles-own.md
+++ b/.changeset/fruity-needles-own.md
@@ -2,4 +2,4 @@
 '@solid-design-system/docs': patch
 ---
 
-Added missing labels to `sd-optogroup` screenshot tests and stories to address a11y violations.
+Added missing labels to `sd-optgroup` screenshot tests and stories to address a11y violations.

--- a/.changeset/fruity-needles-own.md
+++ b/.changeset/fruity-needles-own.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/docs': patch
+---
+
+Added missing labels to `sd-optogroup` screenshot tests and stories to address a11y violations.

--- a/.changeset/hip-peas-pick.md
+++ b/.changeset/hip-peas-pick.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/components': patch
+---
+
+Updated `sd-optgroup` option wrapper role from `group` to `listbox` to align with HTML standards and included a localized `aria-label`.

--- a/packages/components/src/components/optgroup/optgroup.ts
+++ b/packages/components/src/components/optgroup/optgroup.ts
@@ -1,6 +1,7 @@
 import { css } from 'lit';
 import { customElement } from '../../internal/register-custom-element';
 import { html } from 'lit/static-html.js';
+import { LocalizeController } from '../../utilities/localize';
 import { property, query } from 'lit/decorators.js';
 import { watch } from '../../internal/watch.js';
 import cx from 'classix';
@@ -29,6 +30,8 @@ import type SdOption from '../option/option';
 
 @customElement('sd-optgroup')
 export default class SdOptgroup extends SolidElement {
+  private readonly localize = new LocalizeController(this);
+
   static dependencies = {
     'sd-divider': SdDivider
   };
@@ -83,7 +86,7 @@ export default class SdOptgroup extends SolidElement {
             <span>${this.label}</span>
           </slot>
         </div>
-        <div role="group" part="options">
+        <div role="listbox" part="options" aria-label="${this.localize.term('optionsList')}">
           <slot @slotchange=${this.handleDisableOptions}></slot>
         </div>
       </div>

--- a/packages/components/src/components/optgroup/optgroup.ts
+++ b/packages/components/src/components/optgroup/optgroup.ts
@@ -86,7 +86,7 @@ export default class SdOptgroup extends SolidElement {
             <span>${this.label}</span>
           </slot>
         </div>
-        <div role="listbox" part="options" aria-label="${this.localize.term('optionsList')}">
+        <div role="listbox" part="options" aria-label="${this.localize.term('optionGroup')}">
           <slot @slotchange=${this.handleDisableOptions}></slot>
         </div>
       </div>

--- a/packages/components/src/translations/de.ts
+++ b/packages/components/src/translations/de.ts
@@ -26,6 +26,7 @@ const translation: Translation = {
     return `Optionen ausgewählt (${num})`;
   },
   openTranscript: 'Abschrift öffnen',
+  optionsList: 'Optionenliste',
   pauseAudio: 'Audio pausieren',
   playAudio: 'Audio abspielen',
   playbackSpeed: 'Wiedergabe Geschwindigkeit',

--- a/packages/components/src/translations/de.ts
+++ b/packages/components/src/translations/de.ts
@@ -26,7 +26,7 @@ const translation: Translation = {
     return `Optionen ausgewählt (${num})`;
   },
   openTranscript: 'Abschrift öffnen',
-  optionsList: 'Optionenliste',
+  optionGroup: 'Optionsgruppe',
   pauseAudio: 'Audio pausieren',
   playAudio: 'Audio abspielen',
   playbackSpeed: 'Wiedergabe Geschwindigkeit',

--- a/packages/components/src/translations/en.ts
+++ b/packages/components/src/translations/en.ts
@@ -26,6 +26,7 @@ const translation: Translation = {
     return `Options Selected (${num})`;
   },
   openTranscript: 'Open transcript',
+  optionsList: 'Options list',
   pauseAudio: 'Pause Audio',
   playAudio: 'Play Audio',
   playbackSpeed: 'Playback Speed',

--- a/packages/components/src/translations/en.ts
+++ b/packages/components/src/translations/en.ts
@@ -26,7 +26,7 @@ const translation: Translation = {
     return `Options Selected (${num})`;
   },
   openTranscript: 'Open transcript',
-  optionsList: 'Options list',
+  optionGroup: 'Option Group',
   pauseAudio: 'Pause Audio',
   playAudio: 'Play Audio',
   playbackSpeed: 'Playback Speed',

--- a/packages/components/src/utilities/localize.ts
+++ b/packages/components/src/utilities/localize.ts
@@ -91,7 +91,7 @@ export interface Translation extends DefaultTranslation {
   notifications: string;
   numOptionsSelected: (num: number) => string;
   openTranscript: string;
-  optionsList: string;
+  optionGroup: string;
   pauseAudio: string;
   playAudio: string;
   playbackSpeed: string;

--- a/packages/components/src/utilities/localize.ts
+++ b/packages/components/src/utilities/localize.ts
@@ -91,6 +91,7 @@ export interface Translation extends DefaultTranslation {
   notifications: string;
   numOptionsSelected: (num: number) => string;
   openTranscript: string;
+  optionsList: string;
   pauseAudio: string;
   playAudio: string;
   playbackSpeed: string;

--- a/packages/docs/src/stories/components/optgroup.stories.ts
+++ b/packages/docs/src/stories/components/optgroup.stories.ts
@@ -19,7 +19,7 @@ const { generateTemplate } = storybookTemplate('sd-optgroup');
 
 export default {
   title: 'Components/sd-optgroup',
-  tags: ['!dev', 'skip-a11y'],
+  tags: ['!dev'],
   component: 'sd-optgroup',
   args: overrideArgs([
     {
@@ -59,7 +59,7 @@ export const Default = {
   },
   render: (args: unknown) => html`
     <div class="h-[260px] w-[400px]">
-      <sd-combobox>
+      <sd-combobox label="Label">
         ${generateTemplate({ args })}
         <sd-optgroup>
           <span slot="label">Section 2</span>
@@ -77,7 +77,7 @@ export const Default = {
 export const Disabled = {
   render: () => html`
     <div class="h-[260px] w-[400px]">
-      <sd-combobox>
+      <sd-combobox label="Label">
         <sd-optgroup label="Section 1" disabled>
           <sd-option value="1">Option</sd-option>
           <sd-option value="2">Option</sd-option>

--- a/packages/docs/src/stories/components/optgroup.test.stories.ts
+++ b/packages/docs/src/stories/components/optgroup.test.stories.ts
@@ -14,7 +14,7 @@ const { generateScreenshotStory } = storybookUtilities;
 
 export default {
   title: 'Components/sd-optgroup/Screenshots: sd-optgroup',
-  tags: ['!autodocs', 'skip-a11y'],
+  tags: ['!autodocs'],
   component: 'sd-optgroup',
   args: overrideArgs([
     {
@@ -55,7 +55,7 @@ export const Default = {
   },
   render: (args: unknown) => html`
     <div class="h-[260px] w-[400px]">
-      <sd-combobox>
+      <sd-combobox label="Label">
         ${generateTemplate({ args })}
         <sd-optgroup>
           <span slot="label">Section 2</span>
@@ -74,7 +74,7 @@ export const Disabled = {
   name: 'Disabled',
   render: () => html`
     <div class="h-[260px] w-[400px]">
-      <sd-combobox>
+      <sd-combobox label="Label">
         <sd-optgroup label="Section 1" disabled>
           <sd-option value="1">Option</sd-option>
           <sd-option value="2">Option</sd-option>
@@ -113,7 +113,7 @@ export const Slots = {
                       ? `<div class="slot slot--border slot--background"><sd-option >Option 1</sd-option><sd-option >Option 2</sd-option></div>`
                       : `<div slot='${slot}' class="slot slot--border slot--background h-6 ${
                           slot === 'label' || slot === 'help-text' ? 'w-20' : 'w-6'
-                        }"></div>`,
+                        }">${slot === 'label' ? 'Label' : ''}</div>`,
                   title: slot
                 }
               ]


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
Closes [#1879 ](https://github.com/solid-design-system/solid/issues/1879)

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
