### PR TITLE
fix: sd-radio, sd-radio-group and sd-radio-button a11y issues

### DIFF
--- a/.changeset/pink-buses-obey.md
+++ b/.changeset/pink-buses-obey.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/components': patch
+---
+
+Improved `sd-radio-group` a11y by adding the attribute `aria-labelledby` to hidden input.

--- a/.changeset/sour-nails-fold.md
+++ b/.changeset/sour-nails-fold.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/docs': patch
+---
+
+Update `sd-radio`, `sd-radio-group` and `sd-radio-button` screenshots tests and stories with missing labels to fix a11y issues.

--- a/packages/components/src/components/radio-group/radio-group.ts
+++ b/packages/components/src/components/radio-group/radio-group.ts
@@ -419,6 +419,7 @@ export default class SdRadioGroup extends SolidElement implements SolidFormContr
                 id="validation-input"
                 type="text"
                 ?required=${this.required}
+                aria-labelledby="label"
                 tabindex="-1"
                 hidden
                 @invalid=${this.handleInvalid}

--- a/packages/docs/src/stories/components/radio-button.test.stories.ts
+++ b/packages/docs/src/stories/components/radio-button.test.stories.ts
@@ -19,13 +19,13 @@ const { generateScreenshotStory } = storybookUtilities;
 
 export default {
   title: 'Components/sd-radio-button/Screenshots: sd-radio-button',
-  tags: ['!autodocs', 'skip-a11y'],
+  tags: ['!autodocs'],
   component: 'sd-radio-button',
   args: overrideArgs([
     {
       type: 'slot',
       name: 'icon',
-      value: '<sd-icon name="system/image" slot="icon"></sd-icon>'
+      value: '<sd-icon name="system/image" slot="icon" label="Label"></sd-icon>'
     }
   ]),
   argTypes,

--- a/packages/docs/src/stories/components/radio-group.stories.ts
+++ b/packages/docs/src/stories/components/radio-group.stories.ts
@@ -21,7 +21,7 @@ const { overrideArgs } = storybookHelpers('sd-radio-group');
 export default {
   title: 'Components/sd-radio-group',
   component: 'sd-radio-group',
-  tags: ['!dev', 'skip-a11y'],
+  tags: ['!dev'],
   parameters: {
     ...parameters,
     design: {

--- a/packages/docs/src/stories/components/radio-group.test.stories.ts
+++ b/packages/docs/src/stories/components/radio-group.test.stories.ts
@@ -16,7 +16,7 @@ const { generateScreenshotStory } = storybookUtilities;
 
 export default {
   title: 'Components/sd-radio-group/Screenshots: sd-radio-group',
-  tags: ['!autodocs', 'skip-a11y'],
+  tags: ['!autodocs'],
   component: 'sd-radio-group',
   parameters: {
     ...parameters,
@@ -220,7 +220,7 @@ export const MouselessWithRadioButtons = {
             type: 'slot',
             name: 'default',
             value:
-              '<sd-radio-button value="1"><sd-icon name="system/image" slot="icon"></sd-icon></sd-radio-button><sd-radio-button value="2"><sd-icon name="system/image" slot="icon"></sd-icon></sd-radio-button><sd-radio-button value="3"><sd-icon name="system/image" slot="icon"></sd-radio-button>'
+              '<sd-radio-button value="1"><sd-icon name="system/image" slot="icon" label="Label"></sd-icon></sd-radio-button><sd-radio-button value="2"><sd-icon name="system/image" slot="icon" label="Label"></sd-icon></sd-radio-button><sd-radio-button value="3"><sd-icon name="system/image" slot="icon" label="Label"></sd-radio-button>'
           },
           {
             type: 'attribute',

--- a/packages/docs/src/stories/components/radio.stories.ts
+++ b/packages/docs/src/stories/components/radio.stories.ts
@@ -16,7 +16,7 @@ const { overrideArgs } = storybookHelpers('sd-radio');
 
 export default {
   title: 'Components/sd-radio',
-  tags: ['!dev', 'skip-a11y'],
+  tags: ['!dev'],
   component: 'sd-radio',
   args: overrideArgs([{ type: 'slot', name: 'default', value: 'Radio' }]),
   argTypes,
@@ -109,7 +109,7 @@ export const Invalid = {
   name: 'Invalid',
   render: () => html`
     <form id="invalid-form" class="flex flex-col gap-8">
-      <sd-radio-group name="radio-group" id="invalid-radio" required boldlabel>
+      <sd-radio-group name="radio-group" id="invalid-radio" required boldlabel label="asd">
         <sd-radio value="1">Radio 1</sd-radio>
         <sd-radio value="2">Radio 2</sd-radio>
         <sd-radio value="3">Radio 3</sd-radio>

--- a/packages/docs/src/stories/components/radio.stories.ts
+++ b/packages/docs/src/stories/components/radio.stories.ts
@@ -109,7 +109,7 @@ export const Invalid = {
   name: 'Invalid',
   render: () => html`
     <form id="invalid-form" class="flex flex-col gap-8">
-      <sd-radio-group name="radio-group" id="invalid-radio" required boldlabel label="asd">
+      <sd-radio-group name="radio-group" id="invalid-radio" required boldlabel>
         <sd-radio value="1">Radio 1</sd-radio>
         <sd-radio value="2">Radio 2</sd-radio>
         <sd-radio value="3">Radio 3</sd-radio>

--- a/packages/docs/src/stories/components/radio.test.stories.ts
+++ b/packages/docs/src/stories/components/radio.test.stories.ts
@@ -13,7 +13,7 @@ const { generateScreenshotStory } = storybookUtilities;
 
 export default {
   title: 'Components/sd-radio/Screenshots: sd-radio',
-  tags: ['!autodocs', 'skip-a11y'],
+  tags: ['!autodocs'],
   component: 'sd-radio',
   args: overrideArgs([{ type: 'slot', name: 'default', value: 'Default Slot' }]),
   argTypes,


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
Closes #1882, closes #1881

## Definition of Reviewable:
- [x] Stories (features, a11y) are created/updated
- [x] relevant tickets are linked
