### PR TITLE
fix: sd-badge template a11y

### DIFF
--- a/.changeset/huge-ducks-spend.md
+++ b/.changeset/huge-ducks-spend.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/docs': patch
+---
+
+Fixed accessibility issue in `sd-badge` template by including missing labels.

--- a/packages/docs/src/stories/components/badge.test.stories.ts
+++ b/packages/docs/src/stories/components/badge.test.stories.ts
@@ -15,7 +15,7 @@ const { generateScreenshotStory } = storybookUtilities;
 export default {
   title: 'Components/sd-badge/Screenshots: sd-badge',
   component: 'sd-badge',
-  tags: ['!autodocs', 'skip-a11y'],
+  tags: ['!autodocs'],
   parameters: {
     ...parameters,
     controls: {

--- a/packages/docs/src/stories/templates/badge.stories.ts
+++ b/packages/docs/src/stories/templates/badge.stories.ts
@@ -2,7 +2,7 @@ import '../../../../components/src/solid-components';
 import { html } from 'lit-html';
 
 export default {
-  tags: ['!dev', 'skip-a11y'],
+  tags: ['!dev'],
   title: 'Templates/Badge',
   parameters: {
     chromatic: { disableSnapshot: true },
@@ -99,14 +99,14 @@ export const NavigationItemWithBadge = {
           </a>
           <div class="flex">
             <sd-navigation-item class="relative">
-              <sd-icon name="system/bell" class="text-xl"></sd-icon>
+              <sd-icon name="system/bell" class="text-xl" label="Open Notifications"></sd-icon>
               <sd-badge class="absolute top-1 -right-5" size="md">
                 +99
                 <span class="sr-only">Notifications</span>
               </sd-badge>
             </sd-navigation-item>
             <sd-navigation-item>
-              <sd-icon name="system/menu" class="text-xl"></sd-icon>
+              <sd-icon name="system/menu" class="text-xl" label="Open menu"></sd-icon>
             </sd-navigation-item>
           </div>
         </div>


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
Closes [#1891 ](https://github.com/solid-design-system/solid/issues/1891)

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
