### PR TITLE
fix: sd-dialog template a11y

### DIFF
--- a/.changeset/spicy-plants-burn.md
+++ b/.changeset/spicy-plants-burn.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/docs': patch
+---
+
+Fixed accessibility violation in `sd-dialog` templates.

--- a/packages/docs/src/stories/components/dialog.test.stories.ts
+++ b/packages/docs/src/stories/components/dialog.test.stories.ts
@@ -14,7 +14,7 @@ const { generateTemplate } = storybookTemplate('sd-dialog');
 
 export default {
   title: 'Components/sd-dialog/Screenshots: sd-dialog',
-  tags: ['!autodocs', 'skip-a11y'],
+  tags: ['!autodocs'],
   component: 'sd-dialog',
   args: overrideArgs([
     {

--- a/packages/docs/src/stories/templates/dialog.stories.ts
+++ b/packages/docs/src/stories/templates/dialog.stories.ts
@@ -2,7 +2,7 @@ import '../../../../components/src/solid-components';
 import { html } from 'lit-html';
 
 export default {
-  tags: ['!dev', 'skip-a11y'],
+  tags: ['!dev'],
   title: 'Templates/Dialog',
   parameters: {
     chromatic: { disableSnapshot: true },
@@ -82,7 +82,7 @@ export const Scrollable = {
       <span slot="headline" class="sd-headline sd-headline--size-3xl">Terms of use</span>
       <sd-scrollable orientation="vertical" step="150" shadows>
         <div class="items-start justify-start h-[300px] lg:h-[454px] space-y-5">
-          <h4 class="sd-headline sd-headline--size-lg">Important notices to our investors</h4>
+          <h3 class="sd-headline sd-headline--size-lg">Important notices to our investors</h3>
           <p class="sd-paragraph">
             By accepting this document, you accept the following restrictions as binding on you:
           </p>


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
Closes [#1892](https://github.com/solid-design-system/solid/issues/1892), closes #1893

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
