### PR TITLE
fix: sd-video a11y

### DIFF
--- a/.changeset/lemon-sloths-sort.md
+++ b/.changeset/lemon-sloths-sort.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/docs': patch
+---
+
+Add missing `alt` attribute in the `sd-video` default story and unskip a11y tests.

--- a/packages/docs/src/stories/components/video.stories.ts
+++ b/packages/docs/src/stories/components/video.stories.ts
@@ -14,7 +14,7 @@ const { generateTemplate } = storybookTemplate('sd-video');
  */
 
 export default {
-  tags: ['!dev', 'skip-a11y'],
+  tags: ['!dev'],
   title: 'Components/sd-video',
   component: 'sd-video',
   args,
@@ -34,7 +34,7 @@ export const Default = {
       constants: {
         type: 'slot',
         name: 'default',
-        value: '<img class="w-[400px] aspect-video object-cover" src="./placeholders/images/generic.jpg" />'
+        value: '<img class="w-[400px] aspect-video object-cover" alt="" src="./placeholders/images/generic.jpg" />'
       },
       args
     });


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
Unskips a11y tests and adds missing alt attribute

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
