### PR TITLE
fix: sd-scrollable a11y

### DIFF
--- a/.changeset/yummy-clouds-fix.md
+++ b/.changeset/yummy-clouds-fix.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/docs': patch
+---
+
+Unskip a11y tests and add missing label in `custom icon` screenshot test for `sd-scrollable`.

--- a/packages/docs/src/stories/components/scrollable.test.stories.ts
+++ b/packages/docs/src/stories/components/scrollable.test.stories.ts
@@ -28,7 +28,7 @@ const defaultSlotContent = `
 
 export default {
   title: 'Components/sd-scrollable/Screenshots: sd-scrollable',
-  tags: ['!autodocs', 'skip-a11y'],
+  tags: ['!autodocs'],
   component: 'sd-scrollable',
   args: overrideArgs({
     type: 'slot',
@@ -104,10 +104,10 @@ export const CustomIcon = {
           <p>Customize the content and attributes as needed.</p>
         </div>
         <div slot="icon-start">
-          <sd-icon name="system/image"></sd-icon>
+          <sd-icon name="system/image" label="Start"></sd-icon>
         </div>
         <div slot="icon-end">
-          <sd-icon name="system/image"></sd-icon>
+          <sd-icon name="system/image" label="End"></sd-icon>
         </div>
       </sd-scrollable>
     `;


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
Unskips a11y tests and adds missing label

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
