### PR TITLE
fix: sd-carousel screenshot test regression

### DIFF
--- a/.changeset/stale-shoes-sparkle.md
+++ b/.changeset/stale-shoes-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/docs': patch
+---
+
+Fix `sd-carousel` screenshot test regression.

--- a/packages/docs/src/stories/components/carousel.test.stories.ts
+++ b/packages/docs/src/stories/components/carousel.test.stories.ts
@@ -93,13 +93,9 @@ export const Inverted = {
             .map(([attr, value]) => `${attr}='${value}'`)
             .join(' ');
 
-          const slotted = Object.entries(slots ?? {})
-            .map(([, slot]) => slot)
-            .join('\n');
-
           return `
             <sd-carousel ${attrs}>
-              ${attributes.inverted ? slotted?.replaceAll('class="slot', 'class="slot slot--inverted') : slotted}
+              ${attributes.inverted ? slots?.default?.replaceAll('class="slot', 'class="slot slot--inverted') : slots?.default}
             </sd-carousel>
           `;
         }


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
<!-- *PR notes: Please describe the changes in this PR.* -->
During our latest sd-carousel PRs, a screenshot test regression has been overlooked. This PR fixes that issue.

![image](https://github.com/user-attachments/assets/814a7d49-c93a-4991-bc71-6fbbbd771dc5)


## Definition of Reviewable:
- [x] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [x] Stories (features, a11y) are created/updated
- [x] relevant tickets are linked
