### PR TITLE
fix: sd-textarea a11y

### DIFF
--- a/.changeset/wide-hands-clean.md
+++ b/.changeset/wide-hands-clean.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/docs': patch
+---
+
+Fix `sd-textarea` a11y tests by adding missing label in screenshot tests.

--- a/packages/docs/src/stories/components/textarea.test.stories.ts
+++ b/packages/docs/src/stories/components/textarea.test.stories.ts
@@ -10,7 +10,7 @@ import { userEvent } from '@storybook/test';
 import { waitUntil } from '@open-wc/testing-helpers';
 import { withActions } from '@storybook/addon-actions/decorator';
 
-const { argTypes, args, parameters } = storybookDefaults('sd-textarea');
+const { argTypes, parameters } = storybookDefaults('sd-textarea');
 const { generateTemplate } = storybookTemplate('sd-textarea');
 const { overrideArgs } = storybookHelpers('sd-textarea');
 const { generateScreenshotStory } = storybookUtilities;

--- a/packages/docs/src/stories/components/textarea.test.stories.ts
+++ b/packages/docs/src/stories/components/textarea.test.stories.ts
@@ -17,9 +17,9 @@ const { generateScreenshotStory } = storybookUtilities;
 
 export default {
   title: 'Components/sd-textarea/Screenshots: sd-textarea',
-  tags: ['!autodocs', 'skip-a11y'],
+  tags: ['!autodocs'],
   component: 'sd-textarea',
-  args,
+  args: overrideArgs([{ type: 'attribute', name: 'label', value: 'Label' }]),
   argTypes: {
     ...argTypes
   },
@@ -343,9 +343,9 @@ export const Slots = {
               title: 'slot=...',
               values: [
                 {
-                  value: `<div slot='${slot}' class="slot slot--border slot--background h-6 ${
+                  value: `<div slot='${slot}' class="slot slot--border slot--background h-6 slot--text ${
                     slot === 'label' || slot === 'help-text' ? 'w-20' : 'w-6'
-                  }"></div>`,
+                  }">${slot === 'label' ? 'Label' : ''}</div>`,
                   title: slot
                 }
               ]


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
Closes [#1981](https://github.com/solid-design-system/solid/issues/1981)

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
