### PR TITLE
fix: sd-select a11y

### DIFF
--- a/.changeset/twenty-rules-invent.md
+++ b/.changeset/twenty-rules-invent.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/docs': patch
+---
+
+Fix `sd-select` a11y tests in screenshot tests by adding missing labels.

--- a/packages/docs/src/stories/components/select.test.stories.ts
+++ b/packages/docs/src/stories/components/select.test.stories.ts
@@ -51,7 +51,7 @@ const labelConstant: ConstantDefinition = { type: 'attribute', name: 'label', va
 // Stories
 export default {
   title: 'Components/sd-select/Screenshots: sd-select',
-  tags: ['!autodocs', 'skip-a11y'],
+  tags: ['!autodocs'],
   component: 'sd-select',
   args: overrideArgs([
     threeOptionsConstant,
@@ -259,7 +259,7 @@ export const Slots = {
                       ? `<div class="slot slot--border slot--background h-8 w-full"></div>`
                       : `<div slot='${slot}' class="slot slot--border slot--background h-6 ${
                           slot === 'label' || slot === 'help-text' ? 'w-20' : 'w-6'
-                        }"></div>`,
+                        }">${slot === 'label' ? 'Label' : ''}</div>`,
                   title: slot
                 }
               ]
@@ -540,7 +540,7 @@ export const setCustomValidity = {
     return html`
       <!-- block submit and show alert instead -->
       <form id="validationForm" class="flex flex-col gap-2">
-        <sd-select id="custom-input" style-on-valid>
+        <sd-select id="custom-input" style-on-valid label="Label">
           <sd-option value="option-1">Option 1</sd-option>
           <sd-option value="option-2">Option 2</sd-option>
           <sd-option value="option-3">Option 3</sd-option>


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
Closes [#1983](https://github.com/solid-design-system/solid/issues/1983)

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
