### PR TITLE
fix: sd-copyright shadow not rendering

### DIFF
--- a/.changeset/purple-comics-wink.md
+++ b/.changeset/purple-comics-wink.md
@@ -1,0 +1,7 @@
+---
+'@solid-design-system/styles': patch
+---
+
+Fix `sd-copyright` default shadow.
+
+- Added missing variables that prevented the `filter` css effect from rendering the correct shadow.

--- a/packages/styles/src/modules/copyright.css
+++ b/packages/styles/src/modules/copyright.css
@@ -11,6 +11,15 @@
 
 .sd-copyright {
   @apply relative;
+  /* Bug fix for drop-shadow-sm */
+  --tw-blur: ;
+  --tw-brightness: ;
+  --tw-contrast: ;
+  --tw-grayscale: ;
+  --tw-hue-rotate: ;
+  --tw-invert: ;
+  --tw-saturate: ;
+  --tw-sepia: ;
 
   &::after {
     @apply block absolute pb-2 pl-4 bottom-0 left-0 text-white text-sm w-full drop-shadow-sm;

--- a/packages/styles/src/solid-styles.css
+++ b/packages/styles/src/solid-styles.css
@@ -10,3 +10,14 @@
 @import url('./modules/status-badge.css');
 /* plop:style */
 @import url('./modules/prose.css');
+
+body {
+  --tw-blur: ;
+  --tw-brightness: ;
+  --tw-contrast: ;
+  --tw-grayscale: ;
+  --tw-hue-rotate: ;
+  --tw-invert: ;
+  --tw-saturate: ;
+  --tw-sepia: ;
+}

--- a/packages/styles/src/solid-styles.css
+++ b/packages/styles/src/solid-styles.css
@@ -11,7 +11,7 @@
 /* plop:style */
 @import url('./modules/prose.css');
 
-body {
+:root {
   --tw-blur: ;
   --tw-brightness: ;
   --tw-contrast: ;

--- a/packages/styles/src/solid-styles.css
+++ b/packages/styles/src/solid-styles.css
@@ -10,14 +10,3 @@
 @import url('./modules/status-badge.css');
 /* plop:style */
 @import url('./modules/prose.css');
-
-:root {
-  --tw-blur: ;
-  --tw-brightness: ;
-  --tw-contrast: ;
-  --tw-grayscale: ;
-  --tw-hue-rotate: ;
-  --tw-invert: ;
-  --tw-saturate: ;
-  --tw-sepia: ;
-}


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
This PR fixes the shadow of `sd-copyright` which was not rendering due to missing variables.
The issue is only visible outside of storybook (eg: codepen) and was reported in the support channel.

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
