### PR TITLE
fix: sd-button a11y reaudit

### DIFF
--- a/.changeset/sweet-onions-prove.md
+++ b/.changeset/sweet-onions-prove.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/docs': patch
+---
+
+Fix a11y issue in `sd-button` icon only screenshot test by adding missing label.

--- a/packages/components/src/components/button/button.ts
+++ b/packages/components/src/components/button/button.ts
@@ -264,7 +264,6 @@ export default class SdButton extends SolidElement implements SolidFormControl {
         border transition-colors duration-200 ease-in-out rounded-default
         select-none cursor-[inherit]`,
         !this.inverted ? 'focus-visible:focus-outline' : 'focus-visible:focus-outline-inverted',
-        this.visuallyDisabled && 'focus-visible:outline-none',
         this.loading && 'relative cursor-wait',
         (this.disabled || this.visuallyDisabled) && 'cursor-not-allowed',
         slots['icon-only'] && 'px-0 w-varspacing',

--- a/packages/docs/src/stories/components/button.stories.ts
+++ b/packages/docs/src/stories/components/button.stories.ts
@@ -124,19 +124,19 @@ export const VisuallyDisabled = {
   render: () => {
     return html`
       <div class="flex gap-12 h-[100px] mt-12">
-        <sd-tooltip content="Visually Disabled" trigger="click focus" size="sm" placement="top">
+        <sd-tooltip content="Visually Disabled" trigger="hover focus" size="sm" placement="top">
           <sd-button variant="primary" visually-disabled>Visually Disabled</sd-button>
         </sd-tooltip>
 
-        <sd-tooltip content="Visually Disabled" trigger="click focus" size="sm" placement="top">
+        <sd-tooltip content="Visually Disabled" trigger="hover focus" size="sm" placement="top">
           <sd-button variant="secondary" visually-disabled>Visually Disabled</sd-button>
         </sd-tooltip>
 
-        <sd-tooltip content="Visually Disabled" trigger="click focus" size="sm" placement="top">
+        <sd-tooltip content="Visually Disabled" trigger="hover focus" size="sm" placement="top">
           <sd-button variant="tertiary" visually-disabled>Visually Disabled</sd-button>
         </sd-tooltip>
 
-        <sd-tooltip content="Visually Disabled" trigger="click focus" size="sm" placement="top">
+        <sd-tooltip content="Visually Disabled" trigger="hover focus" size="sm" placement="top">
           <sd-button variant="cta" visually-disabled>Visually Disabled</sd-button>
         </sd-tooltip>
       </div>

--- a/packages/docs/src/stories/components/button.test.stories.ts
+++ b/packages/docs/src/stories/components/button.test.stories.ts
@@ -209,7 +209,7 @@ export const IconOnly = {
       constants: {
         type: 'slot',
         name: 'default',
-        value: '<sd-icon name="system/image"></sd-icon>'
+        value: '<sd-icon name="system/image" label="Icon Button"></sd-icon>'
       },
       args
     });


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
Closes [#2049](https://github.com/solid-design-system/solid/issues/2049)

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
