### PR TITLE
fix: sd-expandable reaudit

### DIFF
--- a/.changeset/cyan-hotels-boil.md
+++ b/.changeset/cyan-hotels-boil.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/components': patch
+---
+
+Fixed a11y issue in `sd-expandable`. Swapped `aria-hidden` with `inert` attribute to make sure all content, including interactive elements, is properly hidden when component state is closed.

--- a/packages/components/src/components/expandable/expandable.test.ts
+++ b/packages/components/src/components/expandable/expandable.test.ts
@@ -99,11 +99,20 @@ describe('<sd-expandable>', () => {
       </sd-expandable>
     `);
     const toggleButton = el.shadowRoot?.querySelector('button');
+    const detailsElement = el.shadowRoot?.querySelector('[part="details"]');
+
     toggleButton?.click(); // Simulate user clicking the toggle button
 
+    await el.updateComplete;
+
     expect(el.open).to.be.true;
+    expect(detailsElement?.hasAttribute('inert')).to.be.false;
 
     toggleButton?.click(); // Click again to close
+
+    await el.updateComplete;
+
     expect(el.open).to.be.false;
+    expect(detailsElement?.hasAttribute('inert')).to.be.true;
   });
 });

--- a/packages/components/src/components/expandable/expandable.ts
+++ b/packages/components/src/components/expandable/expandable.ts
@@ -1,5 +1,6 @@
 import { css, html } from 'lit';
 import { customElement } from '../../internal/register-custom-element';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { LocalizeController } from '../../utilities/localize.js';
 import { property, query } from 'lit/decorators.js';
 import { waitForEvent } from '../../internal/event';
@@ -127,7 +128,7 @@ export default class SdExpandable extends SolidElement {
                 `}
           </div>
         </button>
-        <details part="details" aria-hidden=${!this.open}>
+        <details part="details" ?inert=${ifDefined(!this.open)}>
           <summary part="summary" aria-hidden="true" class="cursor-pointer overflow-hidden list-none">
             <slot name="clone"></slot>
           </summary>


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
Closes [#2051](https://github.com/solid-design-system/solid/issues/2051)

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
