### PR TITLE
fix: sd-input a11y reaudit

### DIFF
--- a/.changeset/spotty-apples-share.md
+++ b/.changeset/spotty-apples-share.md
@@ -5,3 +5,4 @@
 Improve `sd-input` accessibility.
 
 - Make shown/ hide password button focusable and include `aria-pressed` attribute.
+- Add `aria-invalid` attribute to semantically communicate invalid state.

--- a/.changeset/spotty-apples-share.md
+++ b/.changeset/spotty-apples-share.md
@@ -1,0 +1,7 @@
+---
+'@solid-design-system/components': patch
+---
+
+Improve `sd-input` accessibility.
+
+- Make shown/ hide password button focusable and include `aria-pressed` attribute.

--- a/.changeset/spotty-apples-share.md
+++ b/.changeset/spotty-apples-share.md
@@ -4,5 +4,5 @@
 
 Improve `sd-input` accessibility.
 
-- Make shown/ hide password button focusable and include `aria-pressed` attribute.
+- Make shown/ hide password button focusable.
 - Add `aria-invalid` attribute to semantically communicate invalid state.

--- a/packages/components/src/components/input/input.ts
+++ b/packages/components/src/components/input/input.ts
@@ -646,7 +646,6 @@ export default class SdInput extends SolidElement implements SolidFormControl {
                     class=${cx('flex items-center sd-interactive', iconMarginLeft)}
                     type="button"
                     @click=${this.handlePasswordToggle}
-                    aria-pressed=${this.passwordVisible ? 'true' : 'false'}
                   >
                     ${this.passwordVisible
                       ? html`

--- a/packages/components/src/components/input/input.ts
+++ b/packages/components/src/components/input/input.ts
@@ -610,6 +610,7 @@ export default class SdInput extends SolidElement implements SolidFormControl {
               inputmode=${ifDefined(this.inputmode)}
               aria-describedby="help-text invalid-message"
               aria-disabled=${this.visuallyDisabled || this.disabled ? 'true' : 'false'}
+              aria-invalid=${this.showInvalidStyle}
               @change=${this.handleChange}
               @input=${this.handleInput}
               @invalid=${this.handleInvalid}

--- a/packages/components/src/components/input/input.ts
+++ b/packages/components/src/components/input/input.ts
@@ -643,28 +643,20 @@ export default class SdInput extends SolidElement implements SolidFormControl {
                   <button
                     aria-label=${this.localize.term(this.passwordVisible ? 'hidePassword' : 'showPassword')}
                     part="password-toggle-button"
-                    class="flex items-center"
+                    class=${cx('flex items-center sd-interactive', iconMarginLeft)}
                     type="button"
                     @click=${this.handlePasswordToggle}
-                    tabindex="-1"
+                    aria-pressed=${this.passwordVisible ? 'true' : 'false'}
                   >
                     ${this.passwordVisible
                       ? html`
                           <slot name="show-password-icon"
-                            ><sd-icon
-                              class=${cx(iconColor, iconMarginLeft, iconSize)}
-                              library="system"
-                              name="eye"
-                            ></sd-icon
+                            ><sd-icon class=${cx(iconColor, iconSize)} library="system" name="eye"></sd-icon
                           ></slot>
                         `
                       : html`
                           <slot name="hide-password-icon"
-                            ><sd-icon
-                              class=${cx(iconColor, iconMarginLeft, iconSize)}
-                              library="system"
-                              name="eye-crossed-out"
-                            ></sd-icon
+                            ><sd-icon class=${cx(iconColor, iconSize)} library="system" name="eye-crossed-out"></sd-icon
                           ></slot>
                         `}
                   </button>


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
Closes [#2054](https://github.com/solid-design-system/solid/issues/2054)

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
