### PR TITLE
fix: boolean properties in storybook

### DIFF
--- a/.changeset/true-meals-join.md
+++ b/.changeset/true-meals-join.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/docs': patch
+---
+
+Improve code examples by removing empty double quotes (`=""`) from boolean attributes.

--- a/packages/docs/scripts/storybook/helper.ts
+++ b/packages/docs/scripts/storybook/helper.ts
@@ -640,8 +640,8 @@ export const storybookUtilities = {
       .replace(/<!-- preview-ignore:start -->[\s\S]*?<!-- preview-ignore:end -->/g, '')
       .replace(/\/\/ preview-ignore:start[\s\S]*?\/\/ preview-ignore:end/g, '')
       .replace(/<style>\n<\/style>/g, '')
-      .replace(/<script>\s*component = document\.querySelector\('(.+?)'\);\s*<\/script>/g, '');
-    // return templateInnerHTML;
+      .replace(/<script>\s*component = document\.querySelector\('(.+?)'\);\s*<\/script>/g, '')
+      .replace(/\s*=\s*""/g, '');
     return templateInnerHTML;
   },
 


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
This PR is a continuation of the improvements made in [#2082](https://github.com/solid-design-system/solid/issues/2082).
With this transformation, we remove `=""` from attributes. This is needed to prevent giving the incorrect information to users when clicking "show code" in storybook stories. This is also transformed in codepen.

Current behaviour (see inverted attribute):
<img width="556" alt="Screenshot 2025-04-02 at 19 02 20" src="https://github.com/user-attachments/assets/dd9cfd68-a58b-40e9-8ed0-ffdb5610c0a7" />

Expected behaviour (see inverted attribute):
<img width="535" alt="Screenshot 2025-04-02 at 19 02 42" src="https://github.com/user-attachments/assets/f13032c7-010c-40e1-a9ac-b48695359010" />


## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
