### PR TITLE
fix: not interactive step min font size

### DIFF
--- a/.changeset/eighty-kiwis-cough.md
+++ b/.changeset/eighty-kiwis-cough.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/components': patch
+---
+
+Fix `sd-step` label alignment when `not-interactive` attribute is set and browsers minimum font size is defined.

--- a/packages/components/src/components/step/step.ts
+++ b/packages/components/src/components/step/step.ts
@@ -156,7 +156,13 @@ export default class SdStep extends SolidElement {
               this.disabled
                 ? 'focus-visible:outline-none cursor-not-allowed'
                 : 'focus-visible:focus-outline group-hover:cursor-pointer',
-              this.notInteractive ? (this.size === 'lg' ? 'w-[72px]' : 'w-12') : this.size === 'lg' ? 'w-12' : 'w-8',
+              this.notInteractive
+                ? this.size === 'lg'
+                  ? 'not-interactive-lg'
+                  : 'w-12'
+                : this.size === 'lg'
+                  ? 'w-12'
+                  : 'w-8',
               this.disabled && 'border-neutral-400 text-neutral-700',
               !this.disabled &&
                 !this.current &&
@@ -227,11 +233,15 @@ export default class SdStep extends SolidElement {
       }
 
       .translateLg {
-        transform: translateX(55px);
+        transform: translateX(3.438rem);
       }
 
       .translateSm {
-        transform: translateX(64px);
+        transform: translateX(4rem);
+      }
+
+      .not-interactive-lg {
+        @apply w-[4.5rem];
       }
     `
   ];


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
This PR fixes an issue with the not-interactive step when user browsers font minimum size is set.

To test: 
- go to [sd-step-group](https://solid-design-system.fe.union-investment.de/docs/?path=/docs/components-sd-step-group--docs#not-interactive-1)
- In safari > settings > advanced > accessibility > tick "never use font sizes smaller than" > set it to 32

Current behaviour:
<img width="1042" alt="Screenshot 2025-04-03 at 13 29 32" src="https://github.com/user-attachments/assets/e6490daf-cbb6-410d-b122-653ef32a4173" />

Fixed version:
<img width="1061" alt="Screenshot 2025-04-03 at 13 29 52" src="https://github.com/user-attachments/assets/9b187afc-6f86-442a-8f64-22b10bde9e82" />


## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
