### PR TITLE
fix: sd-switch invalid story

### DIFF
--- a/.changeset/tangy-news-warn.md
+++ b/.changeset/tangy-news-warn.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/docs': patch
+---
+
+Refactored `sd-switch` invalid state story to prevent focus from being set in the element on page load.

--- a/packages/docs/src/stories/components/switch.stories.ts
+++ b/packages/docs/src/stories/components/switch.stories.ts
@@ -64,13 +64,17 @@ export const Required = {
 export const Invalid = {
   render: () => html`
     <form id="invalid-form">
-      <sd-switch required id="invalid-switch">Invalid</sd-switch>
+      <sd-switch checked required id="invalid-switch">Invalid</sd-switch>
       <sd-button id="invalid-button" class="hidden" type="submit"></sd-button>
     </form>
     <script type="module">
-      await Promise.all([customElements.whenDefined('sd-switch')]).then(() => {
-        const button = document.getElementById('invalid-button');
-        button.click();
+      // Wait for custom elements to be defined
+      await Promise.all([customElements.whenDefined('sd-switch'), customElements.whenDefined('sd-button')]).then(() => {
+        const input = document.getElementById('invalid-switch');
+
+        input.click();
+        input.reportValidity();
+        input.setCustomValidity('error-text');
       });
     </script>
   `


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
When opening the `sd-switch` docs, the page scrolls to the botton and focus is placed on the element.
Refactored `invalid` story to prevent this.

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
