### PR TITLE
fix: 🐛 fix a11y for sd-list

### DIFF
--- a/.changeset/early-lies-pull.md
+++ b/.changeset/early-lies-pull.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/styles': patch
+---
+
+make sd-list accessible and make it behaving closer to design

--- a/.changeset/early-lies-pull.md
+++ b/.changeset/early-lies-pull.md
@@ -2,4 +2,4 @@
 '@solid-design-system/styles': patch
 ---
 
-make sd-list accessible and make it behaving closer to design
+Make `sd-list` accessible and make it behave closer to design

--- a/packages/docs/src/stories/styles/list.test.stories.ts
+++ b/packages/docs/src/stories/styles/list.test.stories.ts
@@ -257,6 +257,10 @@ export const HorizontalIconList = {
  */
 export const MixedLists = {
   name: 'Mixed Lists',
+  parameters: {
+    chromatic: { disableSnapshot: true }
+  },
+  tags: ['!dev'],
   render: (args: any) => {
     const preset = (type: string) =>
       html`<preset-type class="sd-list">
@@ -390,11 +394,4 @@ export const MixedLists = {
   }
 };
 
-export const Combination = generateScreenshotStory([
-  Default,
-  OrderedList,
-  UnorderedList,
-  IconList,
-  HorizontalIconList,
-  MixedLists
-]);
+export const Combination = generateScreenshotStory([Default, OrderedList, UnorderedList, IconList, HorizontalIconList]);

--- a/packages/docs/src/stories/styles/list.test.stories.ts
+++ b/packages/docs/src/stories/styles/list.test.stories.ts
@@ -347,10 +347,10 @@ export const MixedLists = {
           <ul>
             <li>
               Dolor sit
-              <ol>
+              <ul>
                 <li>Amet</li>
                 <li>Ut enim ad minim veniam, quis nostrud exercitation</li>
-              </ol>
+              </ul>
             </li>
             <li>
               Dolor sit

--- a/packages/docs/src/stories/styles/list.test.stories.ts
+++ b/packages/docs/src/stories/styles/list.test.stories.ts
@@ -73,42 +73,6 @@ export const Default = {
 
 export const OrderedList = {
   name: 'Ordered List',
-  args: overrideArgs({
-    type: 'slot',
-    name: 'default',
-    value: html`<li>
-        Lorem Ipsum
-        <ol>
-          <li>
-            Dolor sit
-            <ol>
-              <li>Amet</li>
-              <li>Ut enim ad minim veniam, quis nostrud exercitation</li>
-            </ol>
-          </li>
-          <li>
-            Dolor sit
-            <ol>
-              <li>Amet</li>
-              <li>Ut enim ad minim veniam, quis nostrud exercitation</li>
-            </ol>
-          </li>
-        </ol>
-      </li>
-      <li>
-        Lorem Ipsum
-        <ol>
-          <li>
-            Dolor sit
-            <ol>
-              <li>Amet</li>
-              <li>Ut enim ad minim veniam, quis nostrud exercitation</li>
-            </ol>
-          </li>
-        </ol>
-      </li>
-      <li>Lorem Ipsum</li>`
-  }),
   render: (args: any) => {
     return generateTemplate({
       axis: {
@@ -121,7 +85,38 @@ export const OrderedList = {
           colors: ['rgb(var(--sd-color-white, 255 255 255))', 'rgb(var(--sd-color-primary, 0 53 142))']
         },
         templateContent: html`<ol class="%CLASSES%">
-          %SLOT%
+          <li>
+            Lorem Ipsum
+            <ol>
+              <li>
+                Dolor sit
+                <ol>
+                  <li>Amet</li>
+                  <li>Ut enim ad minim veniam, quis nostrud exercitation</li>
+                </ol>
+              </li>
+              <li>
+                Dolor sit
+                <ol>
+                  <li>Amet</li>
+                  <li>Ut enim ad minim veniam, quis nostrud exercitation</li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+          <li>
+            Lorem Ipsum
+            <ol>
+              <li>
+                Dolor sit
+                <ol>
+                  <li>Amet</li>
+                  <li>Ut enim ad minim veniam, quis nostrud exercitation</li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+          <li>Lorem Ipsum</li>
         </ol>`
       }
     });
@@ -130,42 +125,6 @@ export const OrderedList = {
 
 export const UnorderedList = {
   name: 'Unordered List',
-  args: overrideArgs({
-    type: 'slot',
-    name: 'default',
-    value: html`<li>
-        Lorem Ipsum
-        <ul>
-          <li>
-            Dulor sit
-            <ul>
-              <li>Amet</li>
-              <li>Ut enim ad minim veniam, quis nostrud exercitation</li>
-            </ul>
-          </li>
-          <li>
-            Dulor sit
-            <ul>
-              <li>Amet</li>
-              <li>Ut enim ad minim veniam, quis nostrud exercitation</li>
-            </ul>
-          </li>
-        </ul>
-      </li>
-      <li>
-        Lorem Ipsum
-        <ul>
-          <li>
-            Dulor sit
-            <ul>
-              <li>Amet</li>
-              <li>Ut enim ad minim veniam, quis nostrud exercitation</li>
-            </ul>
-          </li>
-        </ul>
-      </li>
-      <li>Lorem Ipsum</li>`
-  }),
   render: (args: any) => {
     return generateTemplate({
       axis: {
@@ -178,7 +137,38 @@ export const UnorderedList = {
           colors: ['rgb(var(--sd-color-white, 255 255 255))', 'rgb(var(--sd-color-primary, 0 53 142))']
         },
         templateContent: html`<ul class="%CLASSES%">
-          %SLOT%
+          <li>
+            Lorem Ipsum
+            <ul>
+              <li>
+                Dulor sit
+                <ul>
+                  <li>Amet</li>
+                  <li>Ut enim ad minim veniam, quis nostrud exercitation</li>
+                </ul>
+              </li>
+              <li>
+                Dulor sit
+                <ul>
+                  <li>Amet</li>
+                  <li>Ut enim ad minim veniam, quis nostrud exercitation</li>
+                </ul>
+              </li>
+            </ul>
+          </li>
+          <li>
+            Lorem Ipsum
+            <ul>
+              <li>
+                Dulor sit
+                <ul>
+                  <li>Amet</li>
+                  <li>Ut enim ad minim veniam, quis nostrud exercitation</li>
+                </ul>
+              </li>
+            </ul>
+          </li>
+          <li>Lorem Ipsum</li>
         </ul>`
       }
     });

--- a/packages/styles/src/modules/list.css
+++ b/packages/styles/src/modules/list.css
@@ -20,8 +20,8 @@
 
   ul,
   ol {
-    @apply pl-[1.4em] pt-[0.75em];
     all: revert;
+    @apply pl-[1.4em] pt-[0.75em];
   }
 
   @supports not (-webkit-hyphens: none) {

--- a/packages/styles/src/modules/list.css
+++ b/packages/styles/src/modules/list.css
@@ -23,22 +23,41 @@
     @apply mt-3;
   }
 
-  li {
-    @apply pl-[0.5em];
+  ul,
+  ol {
+    @apply pt-[0.75em];
   }
 
   ol,
   ul {
-    @apply pt-[0.75em] pl-[2em];
+    @apply pl-[1.4em];
   }
 
-  /* Counter handling for ordered lists. */
-  &:is(ol),
-  ol {
-    & > li {
-      counter-increment: item;
-      &::marker {
-        content: counters(item, '.') '. ';
+  /* 
+   * Safari currently only partially supports the ::marker pseudo class.
+   * Support is limited to color and font-size. Therefore we optimize the numbering only for non-Safari browsers.
+   * https://developer.mozilla.org/en-US/docs/Web/CSS/::marker#browser_compatibility
+   */
+  @supports not (-webkit-hyphens: none) {
+    li {
+      @apply pl-[0.3em];
+    }
+
+    &:is(ol):not(.sd-list--icon),
+    ol {
+      > li > ol {
+        @apply pl-[1.9em];
+        > li {
+          > ol {
+            @apply pl-[2.7em];
+          }
+        }
+      }
+      & > li {
+        counter-increment: item;
+        &::marker {
+          content: counters(item, '.') '. ';
+        }
       }
     }
   }
@@ -56,14 +75,23 @@
     counter-set: item 0;
   }
 
-  &:is(ul):not(.sd-list--icon) > li,
-  ul > li {
-    list-style-type: disc;
-
-    > ul > li {
-      list-style-type: square;
-      > ul > li {
-        list-style-type: '–';
+  &:is(ul):not(.sd-list--icon),
+  ul {
+    @apply pl-[0.5em];
+    > li {
+      @apply pl-[0.75em];
+      list-style-type: '\2022';
+      > ul {
+        @apply pl-[0.3em];
+        > li {
+          list-style-type: '\002B1D';
+          > ul {
+            @apply pl-[0.4em];
+            > li {
+              list-style-type: '\2010';
+            }
+          }
+        }
       }
     }
   }

--- a/packages/styles/src/modules/list.css
+++ b/packages/styles/src/modules/list.css
@@ -8,15 +8,28 @@
 
 .sd-list:not(.sd-list--icon),
 .sd-prose > :is(ol, ul) {
-  @apply text-left py-4;
+  list-style-position: revert;
+  list-style-type: revert;
+  padding: revert;
+
+  ul,
+  ol {
+    all: revert;
+  }
+
+  @apply text-left py-4 pl-4;
 
   li:not(:first-child) {
     @apply mt-3;
   }
 
+  li {
+    @apply pl-[0.5em];
+  }
+
   ol,
   ul {
-    @apply pt-3;
+    @apply pt-[0.75em] pl-[2em];
   }
 
   /* Counter handling for ordered lists. */
@@ -24,7 +37,7 @@
   ol {
     & > li {
       counter-increment: item;
-      &:before {
+      &::marker {
         content: counters(item, '.') '. ';
       }
     }
@@ -43,32 +56,14 @@
     counter-set: item 0;
   }
 
-  /* Styling */
-  li {
-    @apply table;
-    &:before {
-      @apply pr-2 table-cell;
-    }
-  }
-
-  &:is(ul),
-  ul {
-    list-style-type: '';
-  }
-
   &:is(ul):not(.sd-list--icon) > li,
   ul > li {
-    &:before {
-      content: '\2022';
-    }
+    list-style-type: disc;
+
     > ul > li {
-      &:before {
-        content: '\002B1D';
-      }
+      list-style-type: square;
       > ul > li {
-        &:before {
-          content: '\2010';
-        }
+        list-style-type: '–';
       }
     }
   }

--- a/packages/styles/src/modules/list.css
+++ b/packages/styles/src/modules/list.css
@@ -12,11 +12,6 @@
   list-style-type: revert;
   padding: revert;
 
-  ul,
-  ol {
-    all: revert;
-  }
-
   @apply text-left py-4 pl-4;
 
   li:not(:first-child) {
@@ -25,70 +20,81 @@
 
   ul,
   ol {
-    @apply pt-[0.75em];
+    @apply pl-[1.4em] pt-[0.75em];
+    all: revert;
   }
 
-  ol,
-  ul {
-    @apply pl-[1.4em];
-  }
-
-  /* 
-   * Safari currently only partially supports the ::marker pseudo class.
-   * Support is limited to color and font-size. Therefore we optimize the numbering only for non-Safari browsers.
-   * https://developer.mozilla.org/en-US/docs/Web/CSS/::marker#browser_compatibility
-   */
   @supports not (-webkit-hyphens: none) {
+    /* Safari automatically adds some spacing. This adds it for other browsers. */
     li {
       @apply pl-[0.3em];
     }
 
-    &:is(ol):not(.sd-list--icon),
-    ol {
-      > li > ol {
-        @apply pl-[1.9em];
-        > li {
-          > ol {
-            @apply pl-[2.7em];
-          }
-        }
-      }
-      & > li {
+    /*
+     * Ordered lists
+     */
+
+    /* 
+   * Safari currently only partially supports the ::marker pseudo class.
+   * Support is limited to color and font-size. Therefore we optimize the numbering only for non-Safari browsers.
+   * https://developer.mozilla.org/en-US/docs/Web/CSS/::marker#browser_compatibility
+   */
+    /* Level 1 */
+    &:is(ol):not(.sd-list--icon) {
+      counter-reset: item;
+      > li {
         counter-increment: item;
         &::marker {
-          content: counters(item, '.') '. ';
+          content: counters(item, '.', decimal) '. ';
+        }
+        /* Level 2 */
+        > ol {
+          @apply pl-[1.9em];
+          counter-reset: subitem;
+          > li {
+            counter-increment: subitem;
+            &::marker {
+              content: counters(item, '.', decimal) '.' counters(subitem, '.', decimal) '. ';
+            }
+            /* Level 3 */
+            > ol {
+              @apply pl-[2.7em];
+              counter-reset: subsubitem;
+              > li {
+                counter-increment: subsubitem;
+                &::marker {
+                  content: counters(item, '.', decimal) '.' counters(subitem, '.', decimal) '.'
+                    counters(subsubitem, '.', decimal) '. ';
+                }
+              }
+            }
+          }
         }
       }
     }
   }
 
-  /* Add second level */
-  &:is(ol),
-  &:is(ol) > li > ol,
-  ol > li > ol {
-    counter-reset: item;
-  }
+  /*
+   * Unordered lists
+   */
 
-  /* Ordered lists inside unordered lists. */
-  &:is(ul) > li > ol,
-  ul > li > ol {
-    counter-set: item 0;
-  }
-
+  /* Level 1 */
   &:is(ul):not(.sd-list--icon),
   ul {
     @apply pl-[0.5em];
     > li {
       @apply pl-[0.75em];
-      list-style-type: '\2022';
+      list-style-type: '\2022'; /* • */
+      /* Level 2 */
       > ul {
         @apply pl-[0.3em];
         > li {
-          list-style-type: '\002B1D';
+          list-style-type: '\002B1D'; /* · */
+          /* Level 3 */
           > ul {
             @apply pl-[0.4em];
             > li {
-              list-style-type: '\2010';
+              list-style-type: '\2010'; /* - */
             }
           }
         }
@@ -96,6 +102,10 @@
     }
   }
 }
+
+/*
+  * Icon lists
+  */
 
 .sd-list--icon {
   @apply text-left py-4;
@@ -133,6 +143,10 @@
     }
   }
 }
+
+/*
+ * Inverted
+ */
 
 .sd-list--inverted,
 .sd-prose--inverted > :is(ol, ul) {


### PR DESCRIPTION
We had to update the styling of the list, as `display: table` changed the semantics of it.

This led to several updates.

1. For ordered lists we used the `::marker` pseudo class to define ordered sublevels (e. g. `1.1.1`), instead of hacking around with `::before` etc. Unfortunately this is not fully supported in Safari (https://bugs.webkit.org/show_bug.cgi?id=204163, https://developer.mozilla.org/en-US/docs/Web/CSS/::marker). Therefore we fallback there to showing it as `1.`.
2. We had to refine the paddings etc. This chance was used to bring development closer to the Figma design.

Everything was tested with Safari, Edge and Firefox.

![CleanShot 2025-04-09 at 11 55 56](https://github.com/user-attachments/assets/febdf7b0-a117-480d-9b59-d4d7be8cea72)

![CleanShot 2025-04-09 at 11 57 28](https://github.com/user-attachments/assets/c3646b0c-8a5d-483a-a4ce-ac78f1ce143d)

![CleanShot 2025-04-09 at 11 58 53](https://github.com/user-attachments/assets/df7f3551-d4c8-4cb8-80a0-20718521d650)

![CleanShot 2025-04-09 at 11 59 18](https://github.com/user-attachments/assets/1b80e098-5a1a-4a42-839c-83ce9312af25)


## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -→
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -→
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
