### PR TITLE
fix: 🐛 sd-audio a11y and other things

### DIFF
--- a/.changeset/fine-planets-study.md
+++ b/.changeset/fine-planets-study.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/components': patch
+---
+
+fix: update aria-label in sd-audio for playback speed to include current speed value

--- a/.changeset/fine-planets-study.md
+++ b/.changeset/fine-planets-study.md
@@ -2,4 +2,4 @@
 '@solid-design-system/components': patch
 ---
 
-fix: update aria-label in sd-audio for playback speed to include current speed value
+Improved `sd-audio` `aria-label` by including current speed value on playback speed button.

--- a/.changeset/rare-mice-boil.md
+++ b/.changeset/rare-mice-boil.md
@@ -2,4 +2,4 @@
 '@solid-design-system/components': patch
 ---
 
-fix: change type of containingElement property in sd-dropdown
+Adjusted type of `containingElement` property in `sd-dropdown`

--- a/.changeset/rare-mice-boil.md
+++ b/.changeset/rare-mice-boil.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/components': patch
+---
+
+fix: change type of containingElement property in sd-dropdown

--- a/.changeset/silly-gifts-cut.md
+++ b/.changeset/silly-gifts-cut.md
@@ -2,4 +2,4 @@
 '@solid-design-system/components': patch
 ---
 
-components that are needed in other components are now properly imported (e. g. sd-icon inside sd-button)
+Component dependencies are not correctly imported (e.g. `sd-icon` inside `sd-button`)

--- a/.changeset/silly-gifts-cut.md
+++ b/.changeset/silly-gifts-cut.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/components': patch
+---
+
+components that are needed in other components are now properly imported (e. g. sd-icon inside sd-button)

--- a/.changeset/three-roses-agree.md
+++ b/.changeset/three-roses-agree.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/components': patch
+---
+
+make sd-input compatible to autofill with passwords

--- a/.changeset/three-roses-agree.md
+++ b/.changeset/three-roses-agree.md
@@ -2,4 +2,4 @@
 '@solid-design-system/components': patch
 ---
 
-Make sd-input compatible to autofill with passwords
+Make `sd-input` compatible to autofill with passwords

--- a/.changeset/three-roses-agree.md
+++ b/.changeset/three-roses-agree.md
@@ -2,4 +2,4 @@
 '@solid-design-system/components': patch
 ---
 
-make sd-input compatible to autofill with passwords
+Make sd-input compatible to autofill with passwords

--- a/.changeset/true-peas-pump.md
+++ b/.changeset/true-peas-pump.md
@@ -2,4 +2,4 @@
 '@solid-design-system/components': patch
 ---
 
-fix: trigger elements inside ShadowDOMs are correctly re-focused when sd-drawer or sd-dialog closes
+Improved `sd-drawer` and `sd-dialog` focus management by ensuring trigger elements inside shadow DOMs are correctly re-focused when element closes.

--- a/.changeset/true-peas-pump.md
+++ b/.changeset/true-peas-pump.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/components': patch
+---
+
+fix: trigger elements inside ShadowDOMs are correctly re-focused when sd-drawer or sd-dialog closes

--- a/packages/components/CONTRIBUTING.md
+++ b/packages/components/CONTRIBUTING.md
@@ -22,6 +22,16 @@ We ensure consistency and try to minimize bundle size by following these rules:
 - Utilize IDs or part selectors for any custom CSS needs.
 - Use `@apply` inside `css` tagged template literals to generate CSS, but do not use arbitrary values like `mt-[var(--spacing-xxl)]` there (!), as this increases the bundle size of the main TailwindCSS file. Add those custom values as plain CSS outside the `@apply` directive
 
+### Importing other components
+
+When you use a component inside another component, you need to import it in the component file to ensure stability with Cherry Picking. E. g. if you use the `sd-icon` component inside your component, you need to import it like this:
+
+```ts
+import '../icon/icon';
+```
+
+Remember to add `@dependency sd-icon` to your JSDoc comment so that the component is included in the documentation (see [Documentation](#documentation)).
+
 ### Reflecting properties
 
 Properties should always be reflected, the exceptions are rich data properties (eg. Array, Object...) or properties that require to be frequently updated (eg. currentDuration in a video).

--- a/packages/components/src/components/audio/audio.ts
+++ b/packages/components/src/components/audio/audio.ts
@@ -410,7 +410,7 @@ export default class SdAudio extends SolidElement {
           'playback-speed justify-self-start text-base font-bold hover:cursor-pointer sd-interactive',
           this.inverted && 'sd-interactive--inverted'
         )}
-        aria-label="${this.localize.term('playbackSpeed')}"
+        aria-label="${this.localize.term('playbackSpeed')} (${this.speed}x)"
         @click=${this.togglePlaybackSpeed}
         @keydown=${this.togglePlaybackSpeedKeydown}
         part="playback-speed"

--- a/packages/components/src/components/audio/audio.ts
+++ b/packages/components/src/components/audio/audio.ts
@@ -7,8 +7,8 @@ import { LocalizeController } from '../../utilities/localize';
 import { property, query, state } from 'lit/decorators.js';
 import { Wave } from './wave';
 import cx from 'classix';
-import SdDrawer from '../drawer/drawer';
 import SolidElement from '../../internal/solid-element';
+import type SdDrawer from '../drawer/drawer';
 
 /**
  * @summary Used to play audio files that are part of the page content.

--- a/packages/components/src/components/audio/audio.ts
+++ b/packages/components/src/components/audio/audio.ts
@@ -8,8 +8,8 @@ import { LocalizeController } from '../../utilities/localize';
 import { property, query, state } from 'lit/decorators.js';
 import { Wave } from './wave';
 import cx from 'classix';
+import SdDrawer from '../drawer/drawer';
 import SolidElement from '../../internal/solid-element';
-import type SdDrawer from '../drawer/drawer';
 
 /**
  * @summary Used to play audio files that are part of the page content.

--- a/packages/components/src/components/audio/audio.ts
+++ b/packages/components/src/components/audio/audio.ts
@@ -1,3 +1,6 @@
+import '../button/button';
+import '../drawer/drawer';
+import '../icon/icon';
 import { css, html } from 'lit';
 import { customElement } from '../../internal/register-custom-element';
 import { HasSlotController } from '../../internal/slot';
@@ -14,6 +17,8 @@ import type SdDrawer from '../drawer/drawer';
  * @since 3.19.0
  *
  * @dependency sd-icon
+ * @dependency sd-button
+ * @dependency sd-drawer
  *
  * @event sd-playback-start - Emitted when the audio playback starts.
  * @event sd-playback-end - Emitted when the audio playback ends.
@@ -406,7 +411,6 @@ export default class SdAudio extends SolidElement {
           this.inverted && 'sd-interactive--inverted'
         )}
         aria-label="${this.localize.term('playbackSpeed')}"
-        tabindex="0"
         @click=${this.togglePlaybackSpeed}
         @keydown=${this.togglePlaybackSpeedKeydown}
         part="playback-speed"
@@ -440,7 +444,6 @@ export default class SdAudio extends SolidElement {
                 : this.localize.term('openTranscript')}
               @click=${this.showTranscript}
               @keydown=${this.showTranscriptKeydown}
-              tab-index="0"
               part="transcript"
             >
               <sd-icon class="w-6 h-6" name="transcript" library="system"></sd-icon>
@@ -451,7 +454,6 @@ export default class SdAudio extends SolidElement {
           class=${cx('w-6 h-6 hover:cursor-pointer sd-interactive', this.inverted && 'sd-interactive--inverted')}
           part="volume"
           aria-label=${!this.isMuted ? this.localize.term('mute') : this.localize.term('unmute')}
-          tabindex="0"
           @click=${this.toggleMute}
           @keydown=${this.toggleMuteKeydown}
         >
@@ -500,7 +502,6 @@ export default class SdAudio extends SolidElement {
             max="100"
             step="0.001"
             value=${this.progress}
-            tabindex="0"
             @input=${this.handleAudioProgress}
             @keydown=${this.handleAudioProgressKeydown}
             aria-label=${this.localize.term('seekBar')}

--- a/packages/components/src/components/audio/audio.ts
+++ b/packages/components/src/components/audio/audio.ts
@@ -8,7 +8,8 @@ import { property, query, state } from 'lit/decorators.js';
 import { Wave } from './wave';
 import cx from 'classix';
 import SolidElement from '../../internal/solid-element';
-import type SdDrawer from '../drawer/drawer';
+// eslint-disable-next-line
+import SdDrawer from '../drawer/drawer';
 
 /**
  * @summary Used to play audio files that are part of the page content.

--- a/packages/components/src/components/audio/audio.ts
+++ b/packages/components/src/components/audio/audio.ts
@@ -1,5 +1,4 @@
 import '../button/button';
-import '../drawer/drawer';
 import '../icon/icon';
 import { css, html } from 'lit';
 import { customElement } from '../../internal/register-custom-element';

--- a/packages/components/src/components/combobox/combobox.ts
+++ b/packages/components/src/components/combobox/combobox.ts
@@ -16,11 +16,12 @@ import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { waitForEvent } from '../../internal/event.js';
 import { watch } from '../../internal/watch.js';
 import cx from 'classix';
+// eslint-disable-next-line
+import SdPopup from '../popup/popup';
 import SolidElement from '../../internal/solid-element';
 import type { SolidFormControl } from '../../internal/solid-element';
 import type SdOptgroup from '../optgroup/optgroup.js';
 import type SdOption from '../option/option';
-import type SdPopup from '../popup/popup';
 
 /**
  * @summary Comboboxes allow you to choose items from a menu of predefined options.

--- a/packages/components/src/components/combobox/combobox.ts
+++ b/packages/components/src/components/combobox/combobox.ts
@@ -1,3 +1,5 @@
+import '../icon/icon';
+import '../tag/tag';
 import { animateTo, stopAnimations } from '../../internal/animate.js';
 import { css, html, type TemplateResult } from 'lit';
 import { customElement } from '../../internal/register-custom-element';
@@ -14,13 +16,11 @@ import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { waitForEvent } from '../../internal/event.js';
 import { watch } from '../../internal/watch.js';
 import cx from 'classix';
-import SdIcon from '../icon/icon';
-import SdPopup from '../popup/popup';
-import SdTag from '../tag/tag';
 import SolidElement from '../../internal/solid-element';
 import type { SolidFormControl } from '../../internal/solid-element';
 import type SdOptgroup from '../optgroup/optgroup.js';
 import type SdOption from '../option/option';
+import type SdPopup from '../popup/popup';
 
 /**
  * @summary Comboboxes allow you to choose items from a menu of predefined options.
@@ -30,6 +30,7 @@ import type SdOption from '../option/option';
  *
  * @dependency sd-icon
  * @dependency sd-popup
+ * @dependency sd-tag
  *
  * @slot - The listbox options. Must be `<sd-option>` elements.
  *    You can use `<sd-optgroup>`'s to group items visually.
@@ -75,12 +76,6 @@ import type SdOption from '../option/option';
 
 @customElement('sd-combobox')
 export default class SdCombobox extends SolidElement implements SolidFormControl {
-  static dependencies = {
-    'sd-icon': SdIcon,
-    'sd-popup': SdPopup,
-    'sd-tag': SdTag
-  };
-
   private readonly formControlController: FormControlController = new FormControlController(this, {
     assumeInteractionOn: ['sd-blur', 'sd-input']
   });

--- a/packages/components/src/components/dialog/dialog.ts
+++ b/packages/components/src/components/dialog/dialog.ts
@@ -4,6 +4,7 @@ import { animateTo, stopAnimations } from '../../internal/animate';
 import { css, html } from 'lit';
 import { customElement } from '../../internal/register-custom-element';
 import { getAnimation, setDefaultAnimation } from '../../utilities/animation-registry';
+import { getDeepActiveElement } from '../../internal/deep-active-element';
 import { HasSlotController } from '../../internal/slot';
 import { LocalizeController } from '../../utilities/localize';
 import { lockBodyScrolling, unlockBodyScrolling } from '../../internal/scroll';
@@ -140,7 +141,7 @@ export default class SdDialog extends SolidElement {
       // Show
       this.emit('sd-show');
       this.addOpenListeners();
-      this.originalTrigger = document.activeElement as HTMLElement;
+      this.originalTrigger = getDeepActiveElement();
       this.modal.activate();
 
       lockBodyScrolling(this);

--- a/packages/components/src/components/drawer/drawer.test.ts
+++ b/packages/components/src/components/drawer/drawer.test.ts
@@ -156,4 +156,80 @@ describe('<sd-drawer>', () => {
 
     expect(el.open).to.be.false;
   });
+
+  it('should focus trigger element that was focused before after closing', async () => {
+    const el = await fixture<SdDrawer>(html`
+      <sd-drawer>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</sd-drawer>
+    `);
+
+    const trigger = document.createElement('button');
+    trigger.id = 'trigger';
+    trigger.textContent = 'Trigger';
+    document.body.appendChild(trigger);
+
+    // set event listener to focus trigger
+    trigger.addEventListener('click', () => {
+      el.show();
+    });
+
+    // focus trigger element
+    trigger.focus();
+    expect(document.activeElement).to.equal(trigger);
+
+    // open dialog
+    trigger.click();
+    await waitUntil(() => el.open);
+    expect(el.open).to.be.true;
+
+    // close dialog
+    const overlay = el.shadowRoot!.querySelector<HTMLElement>('[part~="overlay"]')!;
+    overlay.click();
+
+    // wait until dialog is closed
+    await waitUntil(() => !el.open);
+    expect(document.activeElement).to.equal(trigger);
+  });
+
+  it('should focus trigger element inside a web component with Shadow Root that was focused before after closing', async () => {
+    const el = await fixture<SdDrawer>(html`
+      <sd-drawer>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</sd-drawer>
+    `);
+    // register a web component with Shadow Root
+    class TestElement extends HTMLElement {
+      constructor() {
+        super();
+        const shadow = this.attachShadow({ mode: 'open' });
+        const trigger = document.createElement('button');
+        trigger.id = 'trigger';
+        trigger.textContent = 'Trigger';
+        shadow.appendChild(trigger);
+      }
+    }
+    customElements.define('test-element', TestElement);
+    const testElement = document.createElement('test-element');
+    document.body.appendChild(testElement);
+    const trigger = testElement.shadowRoot!.querySelector<HTMLElement>('#trigger')!;
+
+    // set event listener to focus trigger
+    trigger.addEventListener('click', () => {
+      el.show();
+    });
+
+    // focus trigger element
+    trigger.focus();
+
+    // open dialog
+    trigger.click();
+    await waitUntil(() => el.open);
+    expect(el.open).to.be.true;
+
+    // close dialog
+    const overlay = el.shadowRoot!.querySelector<HTMLElement>('[part~="overlay"]')!;
+    overlay.click();
+
+    // wait until dialog is closed
+    await waitUntil(() => !el.open);
+    const activeElementInsideTestElement = testElement.shadowRoot!.activeElement;
+    expect(activeElementInsideTestElement).to.equal(trigger);
+  });
 });

--- a/packages/components/src/components/drawer/drawer.ts
+++ b/packages/components/src/components/drawer/drawer.ts
@@ -253,8 +253,6 @@ export default class SdDrawer extends SolidElement {
         setTimeout(() => trigger.focus());
       }
 
-      console.log(trigger);
-
       //Add a11y attributes to close button
       closeButtonBase?.setAttribute('aria-expanded', 'false');
 

--- a/packages/components/src/components/drawer/drawer.ts
+++ b/packages/components/src/components/drawer/drawer.ts
@@ -4,6 +4,7 @@ import { animateTo, stopAnimations } from '../../internal/animate';
 import { css, html } from 'lit';
 import { customElement } from '../../internal/register-custom-element';
 import { getAnimation, setDefaultAnimation } from '../../utilities/animation-registry';
+import { getDeepActiveElement } from 'src/internal/deep-active-element';
 import { HasSlotController } from '../../internal/slot';
 import { LocalizeController } from '../../utilities/localize';
 import { lockBodyScrolling, unlockBodyScrolling } from '../../internal/scroll';
@@ -151,7 +152,9 @@ export default class SdDrawer extends SolidElement {
       // Show
       this.emit('sd-show');
       this.addOpenListeners();
-      this.originalTrigger = document.activeElement as HTMLElement;
+
+      // Check if the original trigger is inside the drawer
+      this.originalTrigger = getDeepActiveElement();
 
       // Lock body scrolling only if the drawer isn't contained
       if (!this.contained) {
@@ -249,6 +252,8 @@ export default class SdDrawer extends SolidElement {
       if (typeof trigger?.focus === 'function') {
         setTimeout(() => trigger.focus());
       }
+
+      console.log(trigger);
 
       //Add a11y attributes to close button
       closeButtonBase?.setAttribute('aria-expanded', 'false');

--- a/packages/components/src/components/drawer/drawer.ts
+++ b/packages/components/src/components/drawer/drawer.ts
@@ -4,7 +4,7 @@ import { animateTo, stopAnimations } from '../../internal/animate';
 import { css, html } from 'lit';
 import { customElement } from '../../internal/register-custom-element';
 import { getAnimation, setDefaultAnimation } from '../../utilities/animation-registry';
-import { getDeepActiveElement } from 'src/internal/deep-active-element';
+import { getDeepActiveElement } from '../../internal/deep-active-element';
 import { HasSlotController } from '../../internal/slot';
 import { LocalizeController } from '../../utilities/localize';
 import { lockBodyScrolling, unlockBodyScrolling } from '../../internal/scroll';

--- a/packages/components/src/components/dropdown/dropdown.ts
+++ b/packages/components/src/components/dropdown/dropdown.ts
@@ -1,4 +1,3 @@
-import '../popup/popup';
 import { animateTo, stopAnimations } from '../../internal/animate';
 import { css, html } from 'lit';
 import { customElement } from '../../internal/register-custom-element';
@@ -11,11 +10,12 @@ import { waitForEvent } from '../../internal/event';
 import { watch } from '../../internal/watch';
 import cx from 'classix';
 import SolidElement from '../../internal/solid-element';
+// eslint-disable-next-line
+import SdPopup from '../popup/popup';
 import type SdButton from '../button/button';
 import type SdMenu from '../../_components/menu/menu'; // This import should be changed as soon as the menu is moved to the components folder
 import type SdMenuItem from '../../_components/menu-item/menu-item'; // This import should be changed as soon as the menu-item is moved to the components folder
 import type SdNavigationItem from '../navigation-item/navigation-item';
-import type SdPopup from '../popup/popup';
 
 /**
  * @summary Dropdowns expose additional content that "drops down" in a panel.

--- a/packages/components/src/components/dropdown/dropdown.ts
+++ b/packages/components/src/components/dropdown/dropdown.ts
@@ -90,7 +90,7 @@ export default class SdDropdown extends SolidElement {
    * The dropdown will close when the user interacts outside of this element (e.g. clicking). Useful for composing other
    * components that use a dropdown internally.
    */
-  @property({ type: String, attribute: false, reflect: true }) containingElement?: HTMLElement;
+  @property({ type: Object }) containingElement?: HTMLElement;
 
   /** The distance in pixels from which to offset the panel away from its trigger. This defaults to `0` for `rounded=false` and to a minimum of `1` for `rounded=true`. */
   @property({ type: Number, reflect: true }) distance = 0;

--- a/packages/components/src/components/expandable/expandable.ts
+++ b/packages/components/src/components/expandable/expandable.ts
@@ -1,3 +1,4 @@
+import '../icon/icon';
 import { css, html } from 'lit';
 import { customElement } from '../../internal/register-custom-element';
 import { ifDefined } from 'lit/directives/if-defined.js';

--- a/packages/components/src/components/input/input.ts
+++ b/packages/components/src/components/input/input.ts
@@ -622,7 +622,10 @@ export default class SdInput extends SolidElement implements SolidFormControl {
               step=${ifDefined(this.step as number)}
               .value=${live(this.value)}
               autocapitalize=${ifDefined(this.type === 'password' ? 'off' : this.autocapitalize)}
-              autocomplete=${ifDefined(this.type === 'password' ? 'off' : this.autocomplete)}
+              autocomplete=${
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                ifDefined(this.autocomplete as any)
+              }
               autocorrect=${ifDefined(this.type === 'password' ? 'off' : this.autocorrect)}
               ?autofocus=${this.autofocus}
               spellcheck=${this.spellcheck}

--- a/packages/components/src/components/navigation-item/navigation-item.ts
+++ b/packages/components/src/components/navigation-item/navigation-item.ts
@@ -1,3 +1,5 @@
+import '../divider/divider';
+import '../icon/icon';
 import { css } from 'lit';
 import { customElement } from '../../internal/register-custom-element';
 import { HasSlotController } from '../../internal/slot';
@@ -14,6 +16,7 @@ import SolidElement from '../../internal/solid-element';
  * @since 1.15.0
  *
  * @dependency sd-divider
+ * @dependency sd-icon
  *
  * @event sd-show - Emitted when the navigation item has has children, no href, and is clicked while HTML details are hidden.
  * @event sd-hide - Emitted when the navigation item has has children, no href, and is clicked while HTML details are shown.

--- a/packages/components/src/components/notification/notification.ts
+++ b/packages/components/src/components/notification/notification.ts
@@ -1,3 +1,5 @@
+import '../button/button';
+import '../icon/icon';
 import { animateTo, stopAnimations } from '../../internal/animate.js';
 import { css, html } from 'lit';
 import { customElement } from '../../internal/register-custom-element.js';
@@ -25,6 +27,7 @@ const toastStackBottomCenter = Object.assign(document.createElement('div'), {
  * @since 1.22.0
  *
  * @dependency sd-button
+ * @dependency sd-icon
  *
  * @slot - The sd-notification's main content.
  * @slot icon - An icon to show in the sd-notification. Works best with `<sd-icon>`.

--- a/packages/components/src/components/quickfact/quickfact.ts
+++ b/packages/components/src/components/quickfact/quickfact.ts
@@ -18,7 +18,8 @@ import SdAccordion from '../accordion/accordion';
  *
  * @csspart icon - The container that wraps the icon.
  *
- * @dependency sd-icon sd-accordion
+ * @dependency sd-icon
+ * @dependency sd-accordion
  */
 @customElement('sd-quickfact')
 export default class SdQuickfact extends SdAccordion {

--- a/packages/components/src/components/radio/radio.ts
+++ b/packages/components/src/components/radio/radio.ts
@@ -1,4 +1,3 @@
-import '../icon/icon';
 import { css, html } from 'lit';
 import { customElement } from '../../internal/register-custom-element';
 import { property, state } from 'lit/decorators.js';
@@ -10,7 +9,7 @@ import SolidElement from '../../internal/solid-element';
  * @summary A radio allows to select only one value from a set of options. Clicking on an unchecked radio will deselect the other one(s).
  * @documentation https://solid.union-investment.com/[storybook-link]/radio
  * @status stable
- * @since 1.20.0
+ * @since 1.20.0sd-icon
  *
  * @slot - The radio's label.
  *

--- a/packages/components/src/components/radio/radio.ts
+++ b/packages/components/src/components/radio/radio.ts
@@ -9,7 +9,7 @@ import SolidElement from '../../internal/solid-element';
  * @summary A radio allows to select only one value from a set of options. Clicking on an unchecked radio will deselect the other one(s).
  * @documentation https://solid.union-investment.com/[storybook-link]/radio
  * @status stable
- * @since 1.20.0sd-icon
+ * @since 1.20.0
  *
  * @slot - The radio's label.
  *

--- a/packages/components/src/components/scrollable/scrollable.ts
+++ b/packages/components/src/components/scrollable/scrollable.ts
@@ -1,3 +1,4 @@
+import '../icon/icon';
 import { css, html } from 'lit';
 import { customElement } from '../../internal/register-custom-element';
 import { LocalizeController } from '../../utilities/localize';
@@ -10,6 +11,8 @@ import SolidElement from '../../internal/solid-element';
  * @documentation https://solid.union-investment.com/[storybook-link]/scrollable
  * @status stable
  * @since 1.0
+ *
+ * @dependency sd-icon
  *
  * @slot - The scrollable's content.
  * @slot icon-start - The scrollable's start icon.

--- a/packages/components/src/components/select/select.ts
+++ b/packages/components/src/components/select/select.ts
@@ -1,3 +1,5 @@
+import '../icon/icon';
+import '../tag/tag';
 import { animateTo, stopAnimations } from '../../internal/animate.js';
 import { css, html } from 'lit';
 import { customElement } from '../../internal/register-custom-element';
@@ -12,13 +14,11 @@ import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { waitForEvent } from '../../internal/event.js';
 import { watch } from '../../internal/watch.js';
 import cx from 'classix';
-import SdIcon from '../icon/icon';
-import SdPopup from '../popup/popup';
-import SdTag from '../tag/tag';
 import SolidElement from '../../internal/solid-element';
 import type { SolidFormControl } from '../../internal/solid-element';
 import type { TemplateResult } from 'lit';
 import type SdOption from '../option/option';
+import type SdPopup from '../popup/popup';
 
 /**
  * @summary Selects allow you to choose items from a menu of predefined options.
@@ -67,12 +67,6 @@ import type SdOption from '../option/option';
  */
 @customElement('sd-select')
 export default class SdSelect extends SolidElement implements SolidFormControl {
-  static dependencies = {
-    'sd-icon': SdIcon,
-    'sd-popup': SdPopup,
-    'sd-tag': SdTag
-  };
-
   private readonly formControlController: FormControlController = new FormControlController(this, {
     assumeInteractionOn: ['sd-blur', 'sd-input']
   });

--- a/packages/components/src/components/select/select.ts
+++ b/packages/components/src/components/select/select.ts
@@ -14,11 +14,12 @@ import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { waitForEvent } from '../../internal/event.js';
 import { watch } from '../../internal/watch.js';
 import cx from 'classix';
+// eslint-disable-next-line
+import SdPopup from '../popup/popup';
 import SolidElement from '../../internal/solid-element';
 import type { SolidFormControl } from '../../internal/solid-element';
 import type { TemplateResult } from 'lit';
 import type SdOption from '../option/option';
-import type SdPopup from '../popup/popup';
 
 /**
  * @summary Selects allow you to choose items from a menu of predefined options.

--- a/packages/components/src/components/step/step.ts
+++ b/packages/components/src/components/step/step.ts
@@ -1,3 +1,4 @@
+import '../icon/icon';
 import { css } from 'lit';
 import { customElement } from '../../internal/register-custom-element';
 import { HasSlotController } from '../../internal/slot';

--- a/packages/components/src/components/tab-group/tab-group.ts
+++ b/packages/components/src/components/tab-group/tab-group.ts
@@ -1,3 +1,4 @@
+import '../icon/icon';
 import { css, html } from 'lit';
 import { customElement } from '../../internal/register-custom-element';
 import { LocalizeController } from '../../utilities/localize';
@@ -14,7 +15,7 @@ import type SdTabPanel from '../tab-panel/tab-panel';
  * @status stable
  * @since 2.6.0
  *
-
+ * @dependency sd-tab
  *
  * @slot - Used for grouping tab panels in the tab group. Must be `<sd-tab-panel>` elements.
  * @slot nav - Used for grouping tabs in the tab group. Must be `<sd-tab>` elements.

--- a/packages/components/src/components/tag/tag.ts
+++ b/packages/components/src/components/tag/tag.ts
@@ -1,3 +1,4 @@
+import '../icon/icon';
 import { css } from 'lit';
 import { customElement } from '../../internal/register-custom-element';
 import { html, literal } from 'lit/static-html.js';
@@ -11,6 +12,8 @@ import SolidElement from '../../internal/solid-element';
  * @documentation https://solid.union-investment.com/[storybook-link]/tag
  * @status stable
  * @since 1.10
+ *
+ * @dependency sd-icon
  *
  * @slot - The tag's content.
  * @slot removable-indicator - The tag's removability indicator.

--- a/packages/components/src/components/textarea/textarea.ts
+++ b/packages/components/src/components/textarea/textarea.ts
@@ -1,3 +1,4 @@
+import '../icon/icon';
 import { css, html } from 'lit';
 import { customElement } from '../../internal/register-custom-element';
 import { defaultValue } from '../../internal/default-value.js';
@@ -19,6 +20,8 @@ import type { SolidFormControl } from '../../internal/solid-element';
  * @slot label - The textarea's label. Alternatively, you can use the `label` attribute.
  * @slot help-text - Text that describes how to use the input. Alternatively, you can use the `help-text` attribute.
  * @slot tooltip - An optional tooltip that helps describe the input. Use this slot with the `sd-tooltip` component.
+ *
+ * @dependency sd-icon
  *
  * @event sd-blur - Emitted when the control loses focus.
  * @event sd-change - Emitted when an alteration to the control's value is committed by the user.

--- a/packages/components/src/components/tooltip/tooltip.ts
+++ b/packages/components/src/components/tooltip/tooltip.ts
@@ -1,4 +1,4 @@
-import '../popup/popup';
+import '../icon/icon';
 import { animateTo, parseDuration, stopAnimations } from '../../internal/animate';
 import { css, html } from 'lit';
 import { customElement } from '../../internal/register-custom-element';
@@ -18,6 +18,7 @@ import type SdPopup from '../popup/popup';
  * @since 1.23.0
  *
  * @dependency sd-popup
+ * @dependency sd-icon
  *
  * @slot - The tooltip's target element. Avoid slotting in more than one element, as subsequent ones will be ignored.
  * @slot anchor - Slot to change the default trigger icon. The default icon is an info circle.

--- a/packages/components/src/components/tooltip/tooltip.ts
+++ b/packages/components/src/components/tooltip/tooltip.ts
@@ -8,6 +8,7 @@ import { property, query } from 'lit/decorators.js';
 import { waitForEvent } from '../../internal/event';
 import { watch } from '../../internal/watch';
 import cx from 'classix';
+// eslint-disable-next-line
 import SdPopup from '../popup/popup';
 import SolidElement from '../../internal/solid-element';
 

--- a/packages/components/src/components/tooltip/tooltip.ts
+++ b/packages/components/src/components/tooltip/tooltip.ts
@@ -8,8 +8,8 @@ import { property, query } from 'lit/decorators.js';
 import { waitForEvent } from '../../internal/event';
 import { watch } from '../../internal/watch';
 import cx from 'classix';
+import SdPopup from '../popup/popup';
 import SolidElement from '../../internal/solid-element';
-import type SdPopup from '../popup/popup';
 
 /**
  * @summary Tooltips display additional information based on a specific action.

--- a/packages/components/src/components/video/video.ts
+++ b/packages/components/src/components/video/video.ts
@@ -1,3 +1,4 @@
+import '../icon/icon';
 import { css, html } from 'lit';
 import { customElement } from '../../internal/register-custom-element';
 import { HasSlotController } from '../../internal/slot';

--- a/packages/components/src/internal/deep-active-element.ts
+++ b/packages/components/src/internal/deep-active-element.ts
@@ -1,0 +1,16 @@
+/**
+ * Check if element has a ShadowRoot and recursively check for focused elements inside
+ *
+ * @param element
+ * @returns HTMLElement | null
+ */
+
+export function getDeepActiveElement(element: Element | null = document.activeElement): HTMLElement | null {
+  if (element?.shadowRoot) {
+    const shadowActiveElement = element.shadowRoot.activeElement;
+    if (shadowActiveElement) {
+      return getDeepActiveElement(shadowActiveElement as HTMLElement);
+    }
+  }
+  return element as HTMLElement;
+}


### PR DESCRIPTION
Closes #2066 

- Improve focus management for elements within ShadowDOMs triggering sd-dialog and sd-drawer.
- Ensure sd-input supports password autofill.
- Update the type of the containingElement property in sd-dropdown.
- Fix component dependencies, so that needed components are automatically imported.
- Adjust aria-label for playback speed to reflect the current speed value.

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [x] Documentation is created/updated
- [x] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [x] relevant tickets are linked
