### PR TITLE
fix: sd-badge default story

### DIFF
--- a/.changeset/late-chairs-travel.md
+++ b/.changeset/late-chairs-travel.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/docs': patch
+---
+
+Fix `sd-badge` default story.

--- a/packages/docs/src/stories/components/badge.stories.ts
+++ b/packages/docs/src/stories/components/badge.stories.ts
@@ -28,7 +28,7 @@ export default {
       url: 'https://www.figma.com/design/YDktJcseQIIQbsuCpoKS4V/Component-Docs?node-id=2116-4927&node-type=section&t=5PpAC3TA3kYF7ufX-0'
     }
   },
-  args: overrideArgs([{ type: 'slot', name: 'blue', value: '8' }]),
+  args: overrideArgs([{ type: 'slot', name: 'default', value: '8' }]),
   argTypes,
   decorators: [withActions] as any
 };


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:

Manuel noticed the following on his a11y re-audit: (#2072)
> The first and second example in the docs have no content. 

This PR addressed this issue.

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [x] Documentation is created/updated
- [x] Stories (features, a11y) are created/updated
- [x] relevant tickets are linked
