### PR TITLE
feat: add metaSlotPosition property

### DIFF
--- a/packages/components/src/components/teaser/teaser.ts
+++ b/packages/components/src/components/teaser/teaser.ts
@@ -1,10 +1,11 @@
-import { css, html } from 'lit';
+import { css, html, nothing } from 'lit';
 import { customElement } from '../../internal/register-custom-element';
 import { HasSlotController } from '../../internal/slot';
 import { property, query, state } from 'lit/decorators.js';
 import cx from 'classix';
 import SolidElement from '../../internal/solid-element';
 import type { PropertyValues } from 'lit';
+
 /**
  * @summary Teasers group information into flexible containers so users can browse a collection of related items and actions.
  * @documentation https://solid.union-investment.com/[storybook-link]/teaser
@@ -43,6 +44,10 @@ export default class SdTeaser extends SolidElement {
 
   /** The teaser's inner padding. This is always set in `white border-neutral-400`. */
   @property({ type: Boolean, reflect: true }) inset = false;
+
+  /** Position of the meta text. Can be positioned above(top) or below(bottom) the headline. Defaults to top. */
+  @property({ type: String, attribute: 'meta-slot-position', reflect: true }) metaSlotPosition: 'top' | 'bottom' =
+    'top';
 
   @query('[part="base"]') teaser: HTMLElement;
 
@@ -111,6 +116,20 @@ export default class SdTeaser extends SolidElement {
         part="base"
       >
         <div
+          part="media"
+          id="media"
+          style=${this._orientation === 'horizontal' ? `width: var(--distribution-media, 100%);` : ''}
+          class=${cx(
+            'order-1',
+            !inset && this._orientation === 'vertical' && 'mb-4',
+            !slots['teaser-has-media'] && 'hidden',
+            this.variant === 'white border-neutral-400' && this._orientation === 'vertical' && 'mx-[-1px] mt-[-1px]'
+          )}
+        >
+          <slot name="media"></slot>
+        </div>
+
+        <div
           style=${this._orientation === 'horizontal'
             ? `width: var(--distribution-content, 100%); ${
                 inset ? 'width: var(--distribution-content, calc(100% - 2rem));' : ''
@@ -123,42 +142,37 @@ export default class SdTeaser extends SolidElement {
           )}
           part="content"
         >
-          <div class="flex flex-col-reverse">
+          <div class="flex flex-col">
+            ${this.metaSlotPosition === 'top'
+              ? html` <div part="meta" class=${cx('gap-2 mb-4', !slots['teaser-has-meta'] && 'hidden')}>
+                  <slot name="meta"></slot>
+                </div>`
+              : nothing}
+
             <div
               part="headline"
               class=${cx('text-lg font-bold m-0', this.variant === 'primary' ? 'text-white' : 'text-black')}
             >
-              <slot name="headline"
-                >Always insert one semantically correct heading element here (e. g. &lt;h2&gt;)</slot
-              >
+              <slot name="headline">
+                Always insert one semantically correct heading element here (e. g. &lt;h2&gt;)
+              </slot>
             </div>
 
-            <div part="meta" class=${cx('gap-2 mb-4', !slots['teaser-has-meta'] && 'hidden')}>
-              <slot name="meta"></slot>
+            ${this.metaSlotPosition === 'bottom'
+              ? html` <div part="meta" class=${cx('gap-2 mt-4 mb-4', !slots['teaser-has-meta'] && 'hidden')}>
+                  <slot name="meta"></slot>
+                </div>`
+              : nothing}
+
+            <div
+              part="main"
+              class=${cx(!slots['teaser-has-default'] && 'hidden')}
+              role="group"
+              aria-labelledby="headline"
+            >
+              <slot></slot>
             </div>
           </div>
-
-          <div
-            part="main"
-            class=${cx(!slots['teaser-has-default'] && 'hidden')}
-            role="group"
-            aria-labelledby="headline"
-          >
-            <slot></slot>
-          </div>
-        </div>
-        <div
-          part="media"
-          id="media"
-          style=${this._orientation === 'horizontal' ? `width: var(--distribution-media, 100%);` : ''}
-          class=${cx(
-            'order-1',
-            !inset && this._orientation === 'vertical' && 'mb-4',
-            !slots['teaser-has-media'] && 'hidden',
-            this.variant === 'white border-neutral-400' && this._orientation === 'vertical' && 'mx-[-1px] mt-[-1px]'
-          )}
-        >
-          <slot name="media"></slot>
         </div>
       </div>
     `;

--- a/packages/docs/src/stories/components/teaser.stories.ts
+++ b/packages/docs/src/stories/components/teaser.stories.ts
@@ -165,6 +165,27 @@ export const MetaSlot = {
 };
 
 /**
+ * Meta slot positioned below the headline.
+ */
+
+export const MetaSlotBottom = {
+  render: () => html`
+    <sd-teaser meta-slot-position="bottom">
+      <h3 slot="headline">Lorem ipsum sic semper</h3>
+      <div slot="meta">
+        <time class="sd-meta sd-meta--pipe" datetime="2023-01-01">01.01.2023</time>
+        <span class="sd-meta">Author name</span>
+      </div>
+      <p>
+        Quis ut ex cupidatat proident cillum ullamco ea aute ad laborum aliqua incididunt sint ipsum. Elit enim
+        reprehenderit aliquip officia in minim. Eu ipsum pariatur dolor. Do ex in cupidatat anim aliqua sint voluptate
+        sunt nulla incididunt.
+      </p>
+    </sd-teaser>
+  `
+};
+
+/**
  * Use the `inset` attribute to create a teaser with an inset padding if the context needs it.
  */
 


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
<!-- *PR notes: New metaSlotPosition property is added. Meta slot can be positioned above or below the headline. New story is added showing meta slot below the headline* -->

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
