### PR TITLE
fix: styles package npm release

### DIFF
--- a/.changeset/eleven-groups-arrive.md
+++ b/.changeset/eleven-groups-arrive.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/styles': patch
+---
+
+Fixed issue with package version to correctly publish package in NPM.

--- a/packages/styles/CHANGELOG.md
+++ b/packages/styles/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Minor Changes
 
+> **Note:** This version is currently unpublished on NPM and cannot be used. All changes introduced here, are available on version 1.4.1
+
 - Adjusted `sd-interactive` transition duration values. _[`#2217`](https://github.com/solid-design-system/solid/pull/2217) [`ac48614`](https://github.com/solid-design-system/solid/commit/ac486145c19c83f646ad16a9dddde35a6e90a6eb) [@paulovareiro29](https://github.com/paulovareiro29)_
 
 ## 1.3.3

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@solid-design-system/styles",
+  "version": "1.4.0",
   "author": {
     "name": "Union Investment"
   },
@@ -43,7 +44,6 @@
     "directory": "packages/styles"
   },
   "type": "module",
-  "version": "1.4.0",
   "devDependencies": {
     "@mariohamann/tailwindcss-var": "^2.1.0",
     "@solid-design-system/versioning": "workspace:^",


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
Last December when the styles package was first released, the initial version was set to 1.4.0 by mistake. It was unpublished from NPM but since it's there, now that the real 1.4.0 needed to be released, it's not possible. This PR bumps the package version to 1.4.1 to ensure the release on NPM and also adds this information to the changelog.

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
