### PR TITLE
fix: render content for `tooltip` with bolded text template

### DIFF
--- a/.changeset/slow-papers-switch.md
+++ b/.changeset/slow-papers-switch.md
@@ -1,0 +1,6 @@
+---
+'@solid-design-system/components': patch
+'@solid-design-system/docs': patch
+---
+
+fix: render content for `tooltip` with bolded text template

--- a/packages/components/src/components/tooltip/tooltip.ts
+++ b/packages/components/src/components/tooltip/tooltip.ts
@@ -4,6 +4,7 @@ import { animateTo, parseDuration, stopAnimations } from '../../internal/animate
 import { css, html } from 'lit';
 import { customElement } from '../../internal/register-custom-element';
 import { getAnimation, setDefaultAnimation } from '../../utilities/animation-registry';
+import { HasSlotController } from '../../internal/slot';
 import { LocalizeController } from '../../utilities/localize';
 import { property, query } from 'lit/decorators.js';
 import { waitForEvent } from '../../internal/event';
@@ -49,6 +50,7 @@ export default class SdTooltip extends SolidElement {
   private interactionType: 'keyboard' | 'mouse' | undefined;
 
   public localize = new LocalizeController(this);
+  private readonly hasSlotController = new HasSlotController(this, '[default]', 'content');
 
   @query('slot:not([name])') defaultSlot: HTMLSlotElement;
   @query('#tooltip') body: HTMLElement;
@@ -137,7 +139,7 @@ export default class SdTooltip extends SolidElement {
   }
 
   private get hasCustomTrigger() {
-    return !!this.querySelector('*:not([slot])');
+    return this.hasSlotController.test('[default]');
   }
 
   // removes empty text nodes from the default slot

--- a/packages/docs/src/stories/templates/tooltip.stories.ts
+++ b/packages/docs/src/stories/templates/tooltip.stories.ts
@@ -91,13 +91,13 @@ export const CheckboxGroupWithTooltip = {
 export const TooltipWithBoldedText = {
   name: 'Tooltip with Bolded Text',
   render: () => html`
-    <div class="h-40 flex items-center pl-20">
-      <sd-tooltip placement="top-start"
-        ><span slot="content" class="sd-prose sd-prose--inverted"
-          ><h5>Guidelines</h5>
-          Document design standards and usage</span
-        ></sd-tooltip
-      >
+    <div class="h-[150px] flex items-center">
+      <sd-tooltip placement="top-start" size="sm">
+        <div slot="content">
+          <p class="sd-headline sd-headline--size-base sd-headline--inverted">Guidelines</p>
+          <p class="sd-paragraph sd-paragraph--size-sm sd-paragraph--inverted">Document design standards and usage</p>
+        </div>
+      </sd-tooltip>
     </div>
   `
 };


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
<!-- *PR notes: Please describe the changes in this PR.* -->
Closes https://github.com/solid-design-system/solid/issues/2170
## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
