### PR TITLE
fix:  add sd-option checkbox fill color

### DIFF
--- a/.changeset/slow-lizards-hide.md
+++ b/.changeset/slow-lizards-hide.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/components': patch
+---
+
+Fixed `sd-option` checkbox fill color

--- a/packages/components/src/components/option/option.ts
+++ b/packages/components/src/components/option/option.ts
@@ -164,7 +164,7 @@ export default class SdOption extends SolidElement {
               part="control ${this.selected ? ' control--checked' : 'control--unchecked'}"
               class=${cx(
                 'relative flex flex-shrink-0 items-center justify-center border rounded-sm h-4 w-4 mr-2',
-                this.disabled ? 'border-neutral-500' : this.selected ? 'bg-accent border-accent' : 'border-neutral-800'
+                this.disabled ? 'border-neutral-500' : this.selected ? 'bg-accent border-accent' : 'bg-white'
               )}
             >
               ${this.selected


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
<!-- *PR notes: Please describe the changes in this PR.* -->
Closes https://github.com/solid-design-system/solid/issues/1341
## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
<!-- *PR notes: If this PR includes a BREAKING CHANGE, a migration guide is needed to explain how users can migrate between versions. * -->
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] relevant tickets are linked
