### PR TITLE
fix: tab panel focus

### DIFF
--- a/.changeset/odd-shoes-pay.md
+++ b/.changeset/odd-shoes-pay.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/docs': patch
+---
+
+Added screenshot test for `sd-tab-group` with links inside the `sd-tab-panel`.

--- a/.changeset/strong-frogs-build.md
+++ b/.changeset/strong-frogs-build.md
@@ -1,0 +1,8 @@
+---
+'@solid-design-system/components': patch
+---
+
+Fixed the following issues in the `sd-tab-group` component:
+
+- `sd-tab-panel` focus was always visible even when tabbing into other child elements. Now it will move the focus to the correct elements.
+- `sd-tab-group` logic to scroll into view the next and previous tab was breaking when on the first or last tab element. Added another validation to prevent it.

--- a/packages/components/src/components/tab-group/tab-group.ts
+++ b/packages/components/src/components/tab-group/tab-group.ts
@@ -169,18 +169,20 @@ export default class SdTabGroup extends SolidElement {
     // Scroll tab into view when tabbing forward
     if (['Tab'].includes(event.key)) {
       const index = this.tabs.indexOf(this.getActiveTab()!);
+      const nextTab = this.tabs[index + 1];
 
-      if (tab !== null) {
-        scrollIntoView(this.tabs[index + 1], this.nav, 'horizontal');
+      if (tab !== null && nextTab) {
+        scrollIntoView(nextTab, this.nav, 'horizontal');
       }
     }
 
     // Scroll tab into view when tabbing backward
     if (['Shift', 'Tab'].includes(event.key)) {
       const index = this.tabs.indexOf(this.getActiveTab()!);
+      const previousTab = this.tabs[index - 1];
 
-      if (tab !== null) {
-        scrollIntoView(this.tabs[index - 1], this.nav, 'horizontal');
+      if (tab !== null && previousTab) {
+        scrollIntoView(previousTab, this.nav, 'horizontal');
       }
     }
 

--- a/packages/components/src/components/tab-group/tab-group.ts
+++ b/packages/components/src/components/tab-group/tab-group.ts
@@ -404,8 +404,11 @@ export default class SdTabGroup extends SolidElement {
       }
 
       ::slotted(sd-tab-panel) {
-        @apply focus-within:focus-outline;
         --padding: 1rem 0;
+      }
+
+      ::slotted(sd-tab-panel:focus-visible) {
+        @apply focus-outline;
       }
     `
   ];

--- a/packages/docs/src/stories/components/tab-group.test.stories.ts
+++ b/packages/docs/src/stories/components/tab-group.test.stories.ts
@@ -394,6 +394,50 @@ export const SampleDeepLink = {
   }
 };
 
+export const SampleWithLinks = {
+  name: 'Sample: With Links',
+  parameters: { ...parameters, docs: { story: { height: '550px' } } },
+  render: () => {
+    return html`
+      <sd-tab-group>
+        <sd-tab slot="nav" panel="tab-1">Tab 1</sd-tab>
+        <sd-tab slot="nav" panel="tab-2">Tab 2</sd-tab>
+        <sd-tab slot="nav" panel="tab-3">Tab 3</sd-tab>
+
+        <sd-tab-panel name="tab-1">
+          <ul class="sd-list">
+            <li>
+              <sd-link href="https://union-investment.com" target="_blank">Union Investment</sd-link>
+            </li>
+            <li>
+              <sd-link href="https://solid-design-system.fe.union-investment.de/docs/" target="_blank"
+                >Solid Design System</sd-link
+              >
+            </li>
+          </ul>
+        </sd-tab-panel>
+        <sd-tab-panel name="tab-2">
+          Odit fugit consequatur illum est eveniet cupiditate distinctio quos. Esse itaque doloribus quis vel. Deleniti
+          vitae alias hic necessitatibus ullam ut inventore sint. At ratione repudiandae accusamus suscipit ipsam
+          necessitatibus illum doloribus saepe. Maxime veritatis ducimus quaerat dolores sequi ullam maxime earum.
+        </sd-tab-panel>
+        <sd-tab-panel name="tab-3">
+          <ul class="sd-list">
+            <li>
+              <sd-link href="https://union-investment.com" target="_blank">Union Investment</sd-link>
+            </li>
+            <li>
+              <sd-link href="https://solid-design-system.fe.union-investment.de/docs/" target="_blank"
+                >Solid Design System</sd-link
+              >
+            </li>
+          </ul>
+        </sd-tab-panel>
+      </sd-tab-group>
+    `;
+  }
+};
+
 export const Combination = generateScreenshotStory([
   Default,
   TabVariants,


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
This PR fixes issue with `sd-tab-panel` focus and logic of the `sd-tab-group` scrollIntoView.

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
<!-- *PR notes: If this PR includes a BREAKING CHANGE, a migration guide is needed to explain how users can migrate between versions. * -->
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
