### PR TITLE
docs: update introduction page [skip chromatic]

### DIFF
--- a/.changeset/spicy-gifts-share.md
+++ b/.changeset/spicy-gifts-share.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/docs': patch
+---
+
+Update introduction page to align with Figma

--- a/packages/docs/src/stories/docs/general/01-Introduction.mdx
+++ b/packages/docs/src/stories/docs/general/01-Introduction.mdx
@@ -57,9 +57,3 @@ Our emphasis is on creating a solid foundation of reliable, maintainable compone
 - **Components**: These are Web Components. They are often more complex than Styles, and could feature reactivity, state, multiple slots, properties, and more.
 - **Styles**: These are standalone CSS files. They don't provide any logic and are often non-interactive.
 - **Templates**: These are complete examples of how to use Styles and Components together. They are often more complex than Components and could feature multiple Components and Styles. They are meant to be copy-pasted and individualized for your project.
-
-> In September 2024, we introduced a major update to our library's documentation. This overhaul significantly improves the developer and designer experience, making it easier to navigate, collaborate, and implement:
->
-> - **Unified**: Our standards of "alignment between development and design" have now been extended to our documentation. We try to document every feature the same way to improve consistency and make handoffs even easier. This includes everything from text to visual examples.
-> - **Features**: Each component/style now has a single page that contains all the information needed to use it. Our documentation pages now focus on describing all the features a component has, and each feature is shown with a small example. Existing stories were moved to a combining screenshot story per component, which was actually their purpose before.
-> - **Templates**: Before our rewrite, we distinguished between "Samples" and "Patterns". This sometimes caused confusion. We decided to combine the two concepts into one and rename them to "Templates", hoping that this would better reflect the understanding of "copy-pastable". They are now listed at the same page level, and additionally at each component used in the template.

--- a/packages/docs/src/stories/docs/general/01-Introduction.mdx
+++ b/packages/docs/src/stories/docs/general/01-Introduction.mdx
@@ -55,5 +55,5 @@ Our emphasis is on creating a solid foundation of reliable, maintainable compone
 ## Structure
 
 - **Components**: A comprehensive set of Figma Design and Web Components offers a seamless user experience and extensive customization options for various design needs and project goals. These components go beyond simple styles: they are often more complex, featuring reactivity, state management, multiple slots, configurable properties, and more.
-- **Styles**: CSS styles can be utilized both in code and as design elements within Figma. They are usually independent, non-interactive files that specify the visual aspects of elements—like color, typography, and spacing—without incorporating any functional logic.
+- **Styles**: CSS styles can be utilized both in code and as design elements within Figma. They are usually independent, non-interactive files that specify the visual aspects of elements — like color, typography, and spacing — without incorporating any functional logic.
 - **Templates**: Reusable design blocks and comprehensive templates offer complete, use-case-specific designs that provide a strong foundation for cohesive and efficient application design.

--- a/packages/docs/src/stories/docs/general/01-Introduction.mdx
+++ b/packages/docs/src/stories/docs/general/01-Introduction.mdx
@@ -54,6 +54,6 @@ Our emphasis is on creating a solid foundation of reliable, maintainable compone
 
 ## Structure
 
-- **Components**: These are Web Components. They are often more complex than Styles, and could feature reactivity, state, multiple slots, properties, and more.
-- **Styles**: These are standalone CSS files. They don't provide any logic and are often non-interactive.
-- **Templates**: These are complete examples of how to use Styles and Components together. They are often more complex than Components and could feature multiple Components and Styles. They are meant to be copy-pasted and individualized for your project.
+- **Components**: A comprehensive set of Figma Design and Web Components offers a seamless user experience and extensive customization options for various design needs and project goals. These components go beyond simple styles: they are often more complex, featuring reactivity, state management, multiple slots, configurable properties, and more.
+- **Styles**: CSS styles can be utilized both in code and as design elements within Figma. They are usually independent, non-interactive files that specify the visual aspects of elements—like color, typography, and spacing—without incorporating any functional logic.
+- **Templates**: Reusable design blocks and comprehensive templates offer complete, use-case-specific designs that provide a strong foundation for cohesive and efficient application design.


### PR DESCRIPTION
## Description:
- removed section on sept. '24 update on the introduction page
- rephrased component, style and template description in order to match with figma texts
- closes #2348 