### PR TITLE
fix: sd-pagination button reset

### DIFF
--- a/.changeset/blue-impalas-burn.md
+++ b/.changeset/blue-impalas-burn.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/styles': patch
+---
+
+Reset button default styles from `sd-pagination`.

--- a/packages/styles/src/modules/pagination.css
+++ b/packages/styles/src/modules/pagination.css
@@ -15,6 +15,12 @@
   ul {
     @apply flex items-center gap-2;
 
+    li button {
+      all: unset;
+
+      @apply border-2 border-transparent border-solid hover:cursor-pointer;
+    }
+
     li a,
     li button {
       @apply no-underline text-primary flex items-center justify-center hover:text-primary-500 active:text-primary-800 transition-[color];
@@ -178,6 +184,8 @@
     ul {
       li:nth-child(2) {
         @apply relative w-8 border-b-2 border-b-accent me-5 after:content-['/'] after:absolute after:-right-[18px] after:scale-y-[1.5];
+
+        border-bottom-style: solid;
       }
 
       li:nth-last-child(2) {


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
While testing the `sd-pagination` in a react app noticed that the button default styles were being applied and also on the `simple pagination` the accent border was not showing up.

Current:
<img width="432" height="175" alt="Screenshot 2025-07-15 at 13 08 51" src="https://github.com/user-attachments/assets/3a2de2cf-c960-4914-865d-16e306aeec64" />

With fix:
<img width="393" height="139" alt="Screenshot 2025-07-15 at 13 09 03" src="https://github.com/user-attachments/assets/560c6437-5cbd-4e62-b5dd-2711332c9682" />

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
<!-- *PR notes: If this PR includes a BREAKING CHANGE, a migration guide is needed to explain how users can migrate between versions. * -->
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
