### PR TITLE
fix: carousel slide count

### DIFF
--- a/.changeset/six-baths-return.md
+++ b/.changeset/six-baths-return.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/components': patch
+---
+
+Fixed an a11y issue in `sd-carousel` where cloned slides where incorrectly included in the total slide count.

--- a/packages/components/src/components/carousel/carousel.ts
+++ b/packages/components/src/components/carousel/carousel.ts
@@ -105,7 +105,9 @@ export default class SdCarousel extends SolidElement {
 
   private autoplayController = new AutoplayController(this, () => this.next());
   private scrollController = new ScrollController(this);
-  private readonly slides = this.getElementsByTagName('sd-carousel-item');
+  private readonly slides = Array.from(this.getElementsByTagName('sd-carousel-item')).filter(
+    el => !el.hasAttribute('data-clone')
+  );
   private intersectionObserver: IntersectionObserver; // determines which slide is displayed
   // A map containing the state of all the slides
   private readonly intersectionObserverEntries = new Map<Element, IntersectionObserverEntry>();


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
<!-- *PR notes: Please describe the changes in this PR.* -->
An issue was reported on the support channel, that the slide count was wrong. After investigation, the problem was because the carousel was incorrectly counting the cloned slides when using the `loop` attribute

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
<!-- *PR notes: If this PR includes a BREAKING CHANGE, a migration guide is needed to explain how users can migrate between versions. * -->
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
