### PR TITLE
fix: make expandable inverted fit to theme

### DIFF
--- a/.changeset/huge-beers-hang.md
+++ b/.changeset/huge-beers-hang.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/components': patch
+---
+
+Adjusted inverted `sd-expandable` to fit to the theming when overriding `--gradient-color-start` and `--gradient-color-end`.

--- a/packages/components/src/components/expandable/expandable.ts
+++ b/packages/components/src/components/expandable/expandable.ts
@@ -189,11 +189,11 @@ export default class SdExpandable extends SolidElement {
     ...SolidElement.styles,
     css`
       :host {
-        --gradient-color-start: rgba(255, 255, 255, 0);
-        --gradient-color-end: rgba(255, 255, 255, 1);
         --component-expandable-max-block-size: 90px;
         --gradient-height: 24px;
-        --gradient: var(--gradient-color-start) 0%, var(--gradient-color-end) 80%, var(--gradient-color-end) 100%;
+        --gradient:
+          var(--gradient-color-start, rgba(255, 255, 255, 0)) 0%, var(--gradient-color-end, rgba(255, 255, 255, 1)) 80%,
+          var(--gradient-color-end, rgba(255, 255, 255, 1)) 100%;
 
         @apply inline-block relative w-full;
       }
@@ -232,11 +232,13 @@ export default class SdExpandable extends SolidElement {
         background: linear-gradient(180deg, var(--gradient));
       }
 
+      :host([inverted]) {
+        --gradient-color-start: rgba(0, 53, 142, 0);
+        --gradient-color-end: rgba(0, 53, 142, 1);
+      }
+
       :host([inverted]) .content::after {
-        background: var(
-          --gradient-vertical-transparent-primary,
-          linear-gradient(180deg, rgba(0, 53, 142, 0) 0%, rgba(0, 53, 142, 1) 80%, rgba(0, 53, 142, 1) 100%)
-        );
+        background: var(--gradient-vertical-transparent-primary, linear-gradient(180deg, var(--gradient)));
       }
 
       :host(:not([open])) .content::after {

--- a/packages/components/src/components/expandable/expandable.ts
+++ b/packages/components/src/components/expandable/expandable.ts
@@ -233,8 +233,9 @@ export default class SdExpandable extends SolidElement {
       }
 
       :host([inverted]) {
-        --gradient-color-start: rgba(0, 53, 142, 0);
-        --gradient-color-end: rgba(0, 53, 142, 1);
+        --color-primary-rgb: 0, 53, 142;
+        --gradient-color-start: rgba(var(--color-primary-rgb), 0);
+        --gradient-color-end: rgba(var(--color-primary-rgb), 1);
       }
 
       :host([inverted]) .content::after {


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->

Steps for testing:
- Go to the `sd-expandable` inverted story.
- Override on the DOM the following variables: `--gradient-color-start` and `--gradient-color-end` to `rgba(45, 157, 0, 0)` and `rgba(45, 157, 0, 1)` respectively.
- On production, the gradient doesn't change color. On this PR it does.

## Description:
Closes #1299 

## Definition of Reviewable:
- [x] relevant tickets are linked
