### PR TITLE
fix: update icon libraries

### DIFF
--- a/.changeset/bitter-experts-happen.md
+++ b/.changeset/bitter-experts-happen.md
@@ -1,0 +1,9 @@
+---
+'@solid-design-system/docs': patch
+---
+
+Updated icon libraries screenshot tests.
+
+- Renamed test `Libray: system` to `Library: internal`.
+- Updated library name from `system` to `_internal`.
+- Added screenshot test `Library: status assets`.

--- a/packages/components/src/components/icon/library.internal.ts
+++ b/packages/components/src/components/icon/library.internal.ts
@@ -1,10 +1,10 @@
 import type { IconLibrary } from './library';
 
 //
-// System icons are a separate library to ensure they're always available, regardless of how the default icon library is
+// Internal icons are a separate library to ensure they're always available, regardless of how the default icon library is
 // configured or if its icons resolve properly.
 //
-// All Solid components must use the system library instead of the default library.
+// All Solid components must use the internal library instead of the default library.
 // For visual consistency, they are a subset of Union Investment's official icons.
 //
 export const icons = {

--- a/packages/docs/src/stories/components/icon.test.stories.ts
+++ b/packages/docs/src/stories/components/icon.test.stories.ts
@@ -1,5 +1,6 @@
 import '../../../../components/src/solid-components';
 import { icons } from '../../../../components/src/components/icon/library.internal';
+import { icons as statusIcons } from '../../../../components/src/components/icon/library.status';
 import { storybookDefaults, storybookHelpers, storybookTemplate } from '../../../scripts/storybook/helper';
 
 const { argTypes, args, parameters } = storybookDefaults('sd-icon');
@@ -46,8 +47,8 @@ export const LibraryDefault = {
     })
 };
 
-export const LibrarySystem = {
-  name: 'Library: system',
+export const LibraryInternal = {
+  name: 'Library: internal',
   render: (args: any) =>
     generateTemplate({
       axis: {
@@ -62,8 +63,34 @@ export const LibrarySystem = {
         }
       },
       constants: [
-        { type: 'attribute', name: 'library', value: 'system' },
+        { type: 'attribute', name: 'library', value: '_internal' },
         { type: 'attribute', name: 'name', value: 'check' }
+      ],
+      options: {
+        templateBackgrounds: { alternate: 'x', colors: ['white', 'white', 'rgb(var(--sd-color-primary, 0 53 142))'] }
+      },
+      args
+    })
+};
+
+export const StatusLibrary = {
+  name: 'Library: status assets',
+  render: (args: any) =>
+    generateTemplate({
+      axis: {
+        x: {
+          type: 'attribute',
+          name: 'color'
+        },
+        y: {
+          type: 'attribute',
+          name: 'name',
+          values: Object.keys(statusIcons)
+        }
+      },
+      constants: [
+        { type: 'attribute', name: 'library', value: 'sd-status-assets' },
+        { type: 'attribute', name: 'name', value: 'status-questionmark' }
       ],
       options: {
         templateBackgrounds: { alternate: 'x', colors: ['white', 'white', 'rgb(var(--sd-color-primary, 0 53 142))'] }


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
Icon screenshot tests still had some references to the old naming `system` which was causing some confusion within the dev teams. Updated and added a new screenshot for the `sd-status-assets` icon library.

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
<!-- *PR notes: If this PR includes a BREAKING CHANGE, a migration guide is needed to explain how users can migrate between versions. * -->
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
