### PR TITLE
fix: checkbox indeterminate

### DIFF
--- a/.changeset/warm-webs-check.md
+++ b/.changeset/warm-webs-check.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/components': patch
+---
+
+Fixed `sd-checkbox` animation to correctly display the `indeterminate` state icon.

--- a/packages/components/src/components/checkbox/checkbox.ts
+++ b/packages/components/src/components/checkbox/checkbox.ts
@@ -267,7 +267,12 @@ export default class SdCheckbox extends SolidElement implements SolidFormControl
             }[checkboxState]
           )}
         >
-          <div class=${cx('absolute h-3 transition-[width] right-0.25 duration-medium', this.checked ? 'w-0' : 'w-3')}>
+          <div
+            class=${cx(
+              'absolute h-3 transition-[width] right-0.25 duration-medium',
+              this.checked || this.indeterminate ? 'w-0' : 'w-3'
+            )}
+          >
             <div
               class=${cx(
                 'w-full h-full transition-colors duration-medium ease-in-out group-hover:duration-fast',


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
This PR fixes an issue with the `sd-checkbox` animation that was not displaying the `indeterminate` icon.

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
<!-- *PR notes: If this PR includes a BREAKING CHANGE, a migration guide is needed to explain how users can migrate between versions. * -->
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
