### PR TITLE
fix: carousel initialization

### DIFF
--- a/.changeset/lemon-sides-itch.md
+++ b/.changeset/lemon-sides-itch.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/components': patch
+---
+
+Fixed issue with `sd-carousel` initialisation where attributes are only added once all slides are ready.


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
When using the `sd-carousel` slotted in another component like the `sd-tab-group`, the `inert` and `aria-hidden` attributes are not set correctly. This happens because the slides are not ready when the attributes are set.

Bug in test environment:

https://github.com/user-attachments/assets/e98511be-3d7e-4f05-87ea-a26bf4bd0a88

With fix:

https://github.com/user-attachments/assets/026f3636-e20c-46bb-b2f6-32b0448351a6


## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
<!-- *PR notes: If this PR includes a BREAKING CHANGE, a migration guide is needed to explain how users can migrate between versions. * -->
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
