### PR TITLE
docs: adding font license hint [skip chromatic]

### DIFF
--- a/packages/docs/src/stories/packages/components/Installation.mdx
+++ b/packages/docs/src/stories/packages/components/Installation.mdx
@@ -21,6 +21,10 @@ We recommend using the CDN of `global-resources` by the CMS project.
 The following CSS gives you a jump start. Please make sure to change `latest`
 to a concrete package version you want to use.
 
+<sd-notification variant="info" duration="Infinity" toast-stack="top-right" open="true">
+    <div class="slot sd-paragraph">When using this jump start, ensure compliance with the SDS license terms, and verify that your use case is explicitly authorized to use the <strong>Frutiger Neue</strong> font.</div>
+</sd-notification>
+
 <sd-accordion summary="Example CSS">
 
 ```css


### PR DESCRIPTION
## Description:
Adding a font license hint to components/installation.mdx in order to make celar, that our jump start is only ment to be used for Union Investment projects.

## Definition of Reviewable:
- [x] Documentation is created/updated
