### PR TITLE
fix: sd-select width overflow

### DIFF
--- a/.changeset/bitter-ties-press.md
+++ b/.changeset/bitter-ties-press.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/components': patch
+---
+
+Fixed `sd-select` input wrapper to prevent elements from overflowing.

--- a/packages/components/src/components/select/select.ts
+++ b/packages/components/src/components/select/select.ts
@@ -983,7 +983,7 @@ export default class SdSelect extends SolidElement implements SolidFormControl {
           >
             <div
               class=${cx(
-                'relative w-full h-full grid grid-cols-1 rounded-default transition-colors hover:duration-fast ease-in-out',
+                'relative w-full h-full grid rounded-default transition-colors hover:duration-fast ease-in-out',
                 this.visuallyDisabled || this.disabled ? 'hover:bg-transparent' : 'hover:bg-neutral-200'
               )}
               slot="anchor"


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
This PR addresses an issue reported in the support channel.

Issue:
<img width="589" height="261" alt="Screenshot 2025-10-08 at 16 50 51" src="https://github.com/user-attachments/assets/aed0ca57-2539-4120-a0f4-adce6f57ae01" />

Fix:
<img width="668" height="257" alt="Screenshot 2025-10-08 at 16 50 41" src="https://github.com/user-attachments/assets/2b99484b-6428-4625-a509-6a93bcc92463" />


## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
<!-- *PR notes: If this PR includes a BREAKING CHANGE, a migration guide is needed to explain how users can migrate between versions. * -->
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
