### PR TITLE
fix: sd-breadcrumb font size

### DIFF
--- a/.changeset/gentle-brooms-write.md
+++ b/.changeset/gentle-brooms-write.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/components': patch
+---
+
+Adjusted `sd-breadcrumb` font-size to `14px` instead of `16px`.

--- a/packages/components/src/components/breadcrumb/breadcrumb.ts
+++ b/packages/components/src/components/breadcrumb/breadcrumb.ts
@@ -165,7 +165,7 @@ export default class SdBreadcrumb extends SolidElement {
 
       sd-dropdown,
       ::slotted(sd-breadcrumb-item) {
-        @apply hidden lg:flex items-center;
+        @apply hidden lg:flex items-center text-sm;
       }
     `
   ];


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
Code and figma were not synced regarding the font-size of the component.

Issue:
<img width="389" height="240" alt="Screenshot 2025-10-08 at 17 06 54" src="https://github.com/user-attachments/assets/563d476b-5b0b-4a94-a643-00908966682b" />

Fix:
<img width="474" height="252" alt="Screenshot 2025-10-08 at 17 06 31" src="https://github.com/user-attachments/assets/466528e2-74fb-48b3-8fed-e162d4787158" />


## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
<!-- *PR notes: If this PR includes a BREAKING CHANGE, a migration guide is needed to explain how users can migrate between versions. * -->
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
