### PR TITLE
fix: update checkbox icon with sd-status-assets icon

### DIFF
--- a/.changeset/funny-planes-mate.md
+++ b/.changeset/funny-planes-mate.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/components': patch
+---
+
+Updated `sd-checkbox` to use icon from `sd-status-assets`.

--- a/packages/components/src/components/checkbox/checkbox.ts
+++ b/packages/components/src/components/checkbox/checkbox.ts
@@ -294,7 +294,7 @@ export default class SdCheckbox extends SolidElement implements SolidFormControl
                 <sd-icon
                   part="checked-icon"
                   class="text-white w-3 h-3"
-                  library="_internal"
+                  library="sd-status-assets"
                   name="status-check"
                 ></sd-icon>
               `
@@ -304,7 +304,7 @@ export default class SdCheckbox extends SolidElement implements SolidFormControl
                 <sd-icon
                   part="indeterminate-icon"
                   class="text-white w-3 h-3"
-                  library="_internal"
+                  library="sd-status-assets"
                   name="status-minus"
                 ></sd-icon>
               `


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
Closes [#1795](https://github.com/solid-design-system/solid/issues/1795)

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
<!-- *PR notes: If this PR includes a BREAKING CHANGE, a migration guide is needed to explain how users can migrate between versions. * -->
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
