### PR TITLE
fix: add missing imports in breadcrumb

### DIFF
--- a/.changeset/brave-owls-smile.md
+++ b/.changeset/brave-owls-smile.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/components': patch
+---
+
+Imported components used inside `sd-breadcrumb` and `sd-breadcrumb-item` to ensure stability when cherry picking.

--- a/packages/components/src/components/breadcrumb-item/breadcrumb-item.ts
+++ b/packages/components/src/components/breadcrumb-item/breadcrumb-item.ts
@@ -1,3 +1,4 @@
+import '../link/link';
 import { css, html } from 'lit';
 import { customElement } from '../../internal/register-custom-element';
 import { ifDefined } from 'lit/directives/if-defined.js';

--- a/packages/components/src/components/breadcrumb/breadcrumb.ts
+++ b/packages/components/src/components/breadcrumb/breadcrumb.ts
@@ -1,3 +1,5 @@
+import '../dropdown/dropdown';
+import '../icon/icon';
 import { css, html } from 'lit';
 import { customElement } from '../../internal/register-custom-element';
 import { LocalizeController } from '../../utilities/localize';


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:

Added imports to make breadcrumb working when being cherry picked.

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
<!-- *PR notes: If this PR includes a BREAKING CHANGE, a migration guide is needed to explain how users can migrate between versions. * -->
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
