### PR TITLE
docs: add package versioning strategy information

### DIFF
--- a/.changeset/ready-words-visit.md
+++ b/.changeset/ready-words-visit.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/docs': patch
+---
+
+Add new package versioning strategy information for `components`, `styles` and `tokens` in installation pages and migration guides.

--- a/packages/docs/.storybook/preview.css
+++ b/packages/docs/.storybook/preview.css
@@ -104,7 +104,8 @@ div[data-radix-scroll-area-viewport]:focus-visible {
   @apply !text-success;
 }
 
-sd-notification#license-hint::part(base) {
+sd-notification#license-hint::part(base),
+sd-notification#versioning-info::part(base) {
   margin-left: 0;
   margin-bottom: 2rem;
 }

--- a/packages/docs/src/stories/packages/components/Installation.mdx
+++ b/packages/docs/src/stories/packages/components/Installation.mdx
@@ -8,6 +8,12 @@ import '../../../../../components/src/solid-components';
 
 You can load Solid Components via CDN or by installing it locally.
 
+<sd-notification type="info" open id="versioning-info">
+  The `components`, `styles`, and `tokens` packages now always share the same version. We use fixed versioning to keep
+  them fully in sync, so every release updates all three packages, even if only one of them changed. Make sure to
+  install or update them using the same version number.
+</sd-notification>
+
 ## Prerequisites
 
 ### Theme

--- a/packages/docs/src/stories/packages/components/Migration/from-v5.mdx
+++ b/packages/docs/src/stories/packages/components/Migration/from-v5.mdx
@@ -11,6 +11,14 @@ The v5 release introduces multi-theming, allowing you to use light and dark mode
 
 It also brings a rework of the `sd-datepicker` attributes to improve consistency with other component attributes.
 
+## Unified Versioning for Components, Styles and Tokens
+
+As part of this release, the packages `components`, `styles` and `tokens` now share a single, synchronized version number. Even if a change occurs in only one package, all three will be released with the same version.
+
+This alignment ensures that all packages stay in sync, there are no mismatches in dependency expectations and simpler updates for consuming projects, since you can always upgrade all packages to the same version.
+
+Going forward, whenever you update the design system, expect new releases of all three packages with the same version, regardless of where the actual code changes occurred.
+
 ## Multi theming
 
 You must now import at least one theme (via NPM or CDN) to ensure components render correctly.

--- a/packages/docs/src/stories/packages/styles/Installation.mdx
+++ b/packages/docs/src/stories/packages/styles/Installation.mdx
@@ -7,6 +7,12 @@ import '../../../../../components/src/solid-components';
 
 You can load Solid via CDN or by installing it locally.
 
+<sd-notification type="info" open id="versioning-info">
+  The `components`, `styles`, and `tokens` packages now always share the same version. We use fixed versioning to keep
+  them fully in sync, so every release updates all three packages, even if only one of them changed. Make sure to
+  install or update them using the same version number.
+</sd-notification>
+
 ## Prerequisites
 
 ### Theme

--- a/packages/docs/src/stories/packages/styles/Migration/from-v5.mdx
+++ b/packages/docs/src/stories/packages/styles/Migration/from-v5.mdx
@@ -1,0 +1,16 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import '../../../../../../components/src/solid-components';
+
+<Meta title="Packages/Styles/Migration/from v5" />
+
+# Migration from v5
+
+The v5 release introduces support for multi-theming tokens.
+
+## Unified Versioning for Components, Styles and Tokens
+
+As part of this release, the packages `components`, `styles` and `tokens` now share a single, synchronized version number. Even if a change occurs in only one package, all three will be released with the same version.
+
+This alignment ensures that all packages stay in sync, there are no mismatches in dependency expectations and simpler updates for consuming projects, since you can always upgrade all packages to the same version.
+
+Going forward, whenever you update the design system, expect new releases of all three packages with the same version, regardless of where the actual code changes occurred.

--- a/packages/docs/src/stories/packages/tokens/Installation.mdx
+++ b/packages/docs/src/stories/packages/tokens/Installation.mdx
@@ -5,6 +5,12 @@ import '../../../../../components/src/solid-components';
 
 # Installation
 
+<sd-notification type="info" open id="versioning-info">
+  The `components`, `styles`, and `tokens` packages now always share the same version. We use fixed versioning to keep
+  them fully in sync, so every release updates all three packages, even if only one of them changed. Make sure to
+  install or update them using the same version number.
+</sd-notification>
+
 ## Prerequisites
 
 ### Fonts

--- a/packages/docs/src/stories/packages/tokens/Migration/from-v5.mdx
+++ b/packages/docs/src/stories/packages/tokens/Migration/from-v5.mdx
@@ -7,6 +7,14 @@ import '../../../../../../components/src/solid-components';
 
 The v5 release introduces support for multi-theming tokens.
 
+## Unified Versioning for Components, Styles and Tokens
+
+As part of this release, the packages `components`, `styles` and `tokens` now share a single, synchronized version number. Even if a change occurs in only one package, all three will be released with the same version.
+
+This alignment ensures that all packages stay in sync, there are no mismatches in dependency expectations and simpler updates for consuming projects, since you can always upgrade all packages to the same version.
+
+Going forward, whenever you update the design system, expect new releases of all three packages with the same version, regardless of where the actual code changes occurred.
+
 ## SCSS Token Naming
 
 We improved our SCSS tokens to match them with our CSS variables:


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
Adds new package versioning strategy information to installation pages and migration guides.

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
<!-- *PR notes: If this PR includes a BREAKING CHANGE, a migration guide is needed to explain how users can migrate between versions. * -->
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
