### PR TITLE
fix: Moved autoplay button before navigation in DOM order for correct…

### DIFF
--- a/.changeset/full-boats-shop.md
+++ b/.changeset/full-boats-shop.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/components': patch
+---
+
+Moved autoplay button before navigation in DOM order for correct screen reader focus sequence

--- a/.changeset/full-boats-shop.md
+++ b/.changeset/full-boats-shop.md
@@ -2,4 +2,4 @@
 '@solid-design-system/components': patch
 ---
 
-Moved autoplay button before navigation in DOM order for correct screen reader focus sequence
+Moved autoplay button in `sd-carousel` before navigation in DOM order for correct screen reader focus sequence

--- a/packages/components/src/components/carousel/carousel.ts
+++ b/packages/components/src/components/carousel/carousel.ts
@@ -364,10 +364,8 @@ export default class SdCarousel extends SolidElement {
   handlePausedAutoplay() {
     if (this.pausedAutoplay) {
       this.autoplayController.stop();
-      this.autoplayControls?.setAttribute('aria-pressed', 'false');
     } else if (this.autoplay) {
       this.autoplayController.start(3000);
-      this.autoplayControls?.setAttribute('aria-pressed', 'true');
     }
   }
 
@@ -652,9 +650,7 @@ export default class SdCarousel extends SolidElement {
             !this.autoplay && '!hidden'
           )}
           part="autoplay-controls"
-          aria-label="${this.pausedAutoplay
-            ? this.localize.term('startAutoplay')
-            : this.localize.term('stopAutoplay')}"
+          aria-label="${this.pausedAutoplay ? this.localize.term('startAutoplay') : this.localize.term('stopAutoplay')}"
           aria-pressed="true"
           @click=${(e: MouseEvent) => {
             this.pausedAutoplay = !this.pausedAutoplay;

--- a/packages/components/src/components/carousel/carousel.ts
+++ b/packages/components/src/components/carousel/carousel.ts
@@ -670,6 +670,34 @@ export default class SdCarousel extends SolidElement {
         </div>
 
         <div part="controls" class=${cx('w-full flex items-center justify-center relative')}>
+          <button
+            class=${cx(
+              'ml-6 !rounded-sm',
+              '!absolute !right-0 sd-interactive',
+              this.inverted ? 'sd-interactive--inverted' : 'sd-interactive--reset',
+              !this.autoplay && '!hidden'
+            )}
+            part="autoplay-controls"
+            aria-label="${this.pausedAutoplay
+              ? this.localize.term('startAutoplay')
+              : this.localize.term('stopAutoplay')}"
+            aria-pressed="true"
+            @click=${(e: MouseEvent) => {
+              this.pausedAutoplay = !this.pausedAutoplay;
+              if (e.detail) {
+                this.autoplayControls.blur();
+              }
+            }}
+          >
+            <slot name="autoplay-start" class=${cx(!this.pausedAutoplay ? 'hidden' : '')}>
+              <sd-icon class="h-6 w-6 grid place-items-center" library="_internal" name="start"></sd-icon>
+            </slot>
+
+            <slot name="autoplay-pause" class=${cx(this.pausedAutoplay ? 'hidden' : '')}>
+              <sd-icon class="h-6 w-6 grid place-items-center" library="_internal" name="pause"></sd-icon>
+            </slot>
+          </button>
+
           <div part="navigation" class=${cx('carousel__navigation flex items-center justify-center')}>
             <button
               part="navigation-button navigation-button--previous"
@@ -801,33 +829,6 @@ export default class SdCarousel extends SolidElement {
               </slot>
             </button>
           </div>
-          <button
-            class=${cx(
-              'ml-6 !rounded-sm',
-              '!absolute !right-0 sd-interactive',
-              this.inverted ? 'sd-interactive--inverted' : 'sd-interactive--reset',
-              !this.autoplay && '!hidden'
-            )}
-            part="autoplay-controls"
-            aria-label="${this.pausedAutoplay
-              ? this.localize.term('startAutoplay')
-              : this.localize.term('stopAutoplay')}"
-            aria-pressed="true"
-            @click=${(e: MouseEvent) => {
-              this.pausedAutoplay = !this.pausedAutoplay;
-              if (e.detail) {
-                this.autoplayControls.blur();
-              }
-            }}
-          >
-            <slot name="autoplay-start" class=${cx(!this.pausedAutoplay ? 'hidden' : '')}>
-              <sd-icon class="h-6 w-6 grid place-items-center" library="_internal" name="start"></sd-icon>
-            </slot>
-
-            <slot name="autoplay-pause" class=${cx(this.pausedAutoplay ? 'hidden' : '')}>
-              <sd-icon class="h-6 w-6 grid place-items-center" library="_internal" name="pause"></sd-icon>
-            </slot>
-          </button>
         </div>
       </div>
     `;

--- a/packages/components/src/components/carousel/carousel.ts
+++ b/packages/components/src/components/carousel/carousel.ts
@@ -641,7 +641,35 @@ export default class SdCarousel extends SolidElement {
     const isLtr = this.localize.dir() === 'ltr';
 
     return html`
-      <div part="base" class=${cx(`carousel h-full w-full`)}>
+      <div part="base" class=${cx(`carousel h-full w-full relative`)}>
+        <button
+          class=${cx(
+            'ml-6 !rounded-sm',
+            '!absolute !bottom-0 !right-0 sd-interactive',
+            this.inverted ? 'sd-interactive--inverted' : 'sd-interactive--reset',
+            !this.autoplay && '!hidden'
+          )}
+          part="autoplay-controls"
+          aria-label="${this.pausedAutoplay
+            ? this.localize.term('startAutoplay')
+            : this.localize.term('stopAutoplay')}"
+          aria-pressed="true"
+          @click=${(e: MouseEvent) => {
+            this.pausedAutoplay = !this.pausedAutoplay;
+            if (e.detail) {
+              this.autoplayControls.blur();
+            }
+          }}
+        >
+          <slot name="autoplay-start" class=${cx(!this.pausedAutoplay ? 'hidden' : '')}>
+            <sd-icon class="h-6 w-6 grid place-items-center" library="_internal" name="start"></sd-icon>
+          </slot>
+
+          <slot name="autoplay-pause" class=${cx(this.pausedAutoplay ? 'hidden' : '')}>
+            <sd-icon class="h-6 w-6 grid place-items-center" library="_internal" name="pause"></sd-icon>
+          </slot>
+        </button>
+
         <div
           class="carousel__announcement sr-only"
           aria-live=${!this.autoplay || this.pausedAutoplay || this.isFocused ? 'polite' : 'off'}
@@ -670,34 +698,6 @@ export default class SdCarousel extends SolidElement {
         </div>
 
         <div part="controls" class=${cx('w-full flex items-center justify-center relative')}>
-          <button
-            class=${cx(
-              'ml-6 !rounded-sm',
-              '!absolute !right-0 sd-interactive',
-              this.inverted ? 'sd-interactive--inverted' : 'sd-interactive--reset',
-              !this.autoplay && '!hidden'
-            )}
-            part="autoplay-controls"
-            aria-label="${this.pausedAutoplay
-              ? this.localize.term('startAutoplay')
-              : this.localize.term('stopAutoplay')}"
-            aria-pressed="true"
-            @click=${(e: MouseEvent) => {
-              this.pausedAutoplay = !this.pausedAutoplay;
-              if (e.detail) {
-                this.autoplayControls.blur();
-              }
-            }}
-          >
-            <slot name="autoplay-start" class=${cx(!this.pausedAutoplay ? 'hidden' : '')}>
-              <sd-icon class="h-6 w-6 grid place-items-center" library="_internal" name="start"></sd-icon>
-            </slot>
-
-            <slot name="autoplay-pause" class=${cx(this.pausedAutoplay ? 'hidden' : '')}>
-              <sd-icon class="h-6 w-6 grid place-items-center" library="_internal" name="pause"></sd-icon>
-            </slot>
-          </button>
-
           <div part="navigation" class=${cx('carousel__navigation flex items-center justify-center')}>
             <button
               part="navigation-button navigation-button--previous"

--- a/packages/components/src/components/carousel/carousel.ts
+++ b/packages/components/src/components/carousel/carousel.ts
@@ -364,8 +364,10 @@ export default class SdCarousel extends SolidElement {
   handlePausedAutoplay() {
     if (this.pausedAutoplay) {
       this.autoplayController.stop();
+      this.autoplayControls?.setAttribute('aria-pressed', 'false');
     } else if (this.autoplay) {
       this.autoplayController.start(3000);
+      this.autoplayControls?.setAttribute('aria-pressed', 'true');
     }
   }
 


### PR DESCRIPTION
… screen reader focus sequence

<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
<!-- *PR notes: Please describe the changes in this PR.* -->
Closes: https://github.com/solid-design-system/solid/issues/2415
- [x] relevant tickets are linked
