### PR TITLE
fix: quality gate failing

### DIFF
--- a/packages/components/src/components/textarea/textarea.test.ts
+++ b/packages/components/src/components/textarea/textarea.test.ts
@@ -374,7 +374,7 @@ describe('<sd-textarea>', () => {
     const el = await fixture<SdTextarea>(html` <sd-textarea label="Name" floating-label></sd-textarea> `);
     await el.updateComplete;
 
-    const label = el.shadowRoot!.querySelector('label[part="form-control-floating-label"]')!;
+    const label = el.shadowRoot!.querySelector<HTMLLabelElement>('label[part="form-control-floating-label"]')!;
     const textarea = el.shadowRoot!.querySelector('textarea')!;
 
     const focusSpy = sinon.spy();

--- a/packages/docs/tsconfig.json
+++ b/packages/docs/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
-    "ignoreDeprecations": "6.0",
     "target": "esnext",
     "module": "esnext",
     "lib": ["dom", "dom.Iterable", "es2022"],


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
Typescript configuration is making `quality gate` fail due to only checking for deprecations on the current installed typescript version which is 5.8 instead of 6.

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
<!-- *PR notes: If this PR includes a BREAKING CHANGE, a migration guide is needed to explain how users can migrate between versions. * -->
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
