### PR TITLE
feat: updating sd-combobox and sd-select docs

### DIFF
--- a/.changeset/fruity-jars-tease.md
+++ b/.changeset/fruity-jars-tease.md
@@ -2,4 +2,5 @@
 '@solid-design-system/docs': patch
 ---
 
-Updating the `sd-combobox` documentation about limiting the height of the dropdown display.
+Updating the `sd-combobox` and `sd-select` documentation about limiting the height of the dropdown display.
+

--- a/.changeset/fruity-jars-tease.md
+++ b/.changeset/fruity-jars-tease.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/docs': patch
+---
+
+Updating the `sd-combobox` documentation about limiting the height of the dropdown display.

--- a/packages/docs/src/stories/components/combobox.mdx
+++ b/packages/docs/src/stories/components/combobox.mdx
@@ -67,7 +67,7 @@ Do not mix the two variants (default / floating label) within the same product, 
 
 - Filter available options in real time as the user types; highlight or bold matching text to indicate relevance.
 - Show a message (e.g., “No matches found”) when no options align with the user’s input.
-- Consider limiting the maximum number of displayed suggestions to avoid overwhelming users.
+- Consider limiting the maximum number of displayed suggestions to avoid overwhelming users. We recommend displaying 6-8 (with scrolling for additional results).
 
 #### Background
 

--- a/packages/docs/src/stories/components/select.mdx
+++ b/packages/docs/src/stories/components/select.mdx
@@ -73,6 +73,7 @@ Do not mix the two variants (default / floating label) within the same product, 
 - Apply the "multiple" attribute when multiple selections are allowed, and pair it with "checkbox" for corresponding nested options.
 - By default, the number of selected options is displayed after the text.
 - Display selected options as tags within the field to help users track their selections.
+- Consider limiting the maximum number of displayed selectable options to avoid overwhelming users. We recommend displaying 6-8 (with scrolling for additional results).
 
 #### Background
 


### PR DESCRIPTION
## Description:
 closes: https://github.com/solid-design-system/solid/issues/2928 

Updating the `sd-combobox` and `sd-select` documentation about limiting the height of the dropdown display.
The code change for the release notes sd-select dropdown is done here: https://github.com/solid-design-system/solid-design-system-showcase/pull/113

## Definition of Reviewable:
- [ ] Documentation is created/updated
- [ ] relevant tickets are linked
