### PR TITLE
fix: eslint-package missing metadata [skip chromatic]

### DIFF
--- a/.changeset/fine-pens-double.md
+++ b/.changeset/fine-pens-double.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/eslint-plugin': patch
+---
+
+Added correct repository metadata for NPM provenance validation during publish.

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -6,6 +6,11 @@
   "author": {
     "name": "Union Investment"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/solid-design-system/solid.git",
+    "directory": "packages/eslint-plugin"
+  },
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
This PR adds missing metadata required for npm provenance validation during publish. 

<img width="1557" height="383" alt="Screenshot 2026-04-28 at 12 28 11" src="https://github.com/user-attachments/assets/91ca7593-6f08-4d6a-a40f-702fcb39dfb1" />


## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
<!-- *PR notes: If this PR includes a BREAKING CHANGE, a migration guide is needed to explain how users can migrate between versions. * -->
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
