### PR TITLE
fix: sd-radio-button checked overlap other radio button states

### DIFF
--- a/.changeset/gentle-keys-find.md
+++ b/.changeset/gentle-keys-find.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/components': patch
+---
+
+Fixing the overlaping of `sd-radio-button`'s in a group.

--- a/packages/components/src/components/radio-button/radio-button.ts
+++ b/packages/components/src/components/radio-button/radio-button.ts
@@ -217,9 +217,12 @@ export default class SdRadioButton extends SolidElement {
         @apply z-20;
       }
 
-      :host(.sd-button-group__button--focus),
+      :host(.sd-button-group__button--focus) {
+        @apply z-30;
+      }
+
       :host(.sd-button-group__button[checked]) {
-        @apply z-10;
+        @apply z-40;
       }
     `
   ];


### PR DESCRIPTION
## Description:
closes: https://github.com/solid-design-system/solid/issues/3008

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
<!-- *PR notes: If this PR includes a BREAKING CHANGE, a migration guide is needed to explain how users can migrate between versions. * -->
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
