### PR TITLE
feat: replace sd-skeleton web component with CSS class (alternative)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -286,7 +286,7 @@ export default [
     files: ['**/*.test.ts']
   })),
   {
-    files: ['**/*.test.ts'],
+    files: ['**/*.test.ts', '**/*.spec.ts'],
 
     rules: {
       '@typescript-eslint/no-unsafe-call': 'off',

--- a/packages/components/src/components/skeleton/skeleton.ts
+++ b/packages/components/src/components/skeleton/skeleton.ts
@@ -7,8 +7,10 @@ import SolidElement from '../../internal/solid-element';
 /**
  * @summary Skeleton loaders are used as placeholder previews of content before data gets loaded.
  * @documentation https://solid.union-investment.com/[storybook-link]/skeleton
- * @status stable
+ * @status deprecated
  * @since 5.17.0
+ *
+ * @deprecated Use the `sd-skeleton` CSS class instead. Apply it directly to the element you want to show as a skeleton and remove it once content is loaded. See the Styles/sd-skeleton documentation.
  *
  * @slot - The skeleton's content. When provided, adapts to the content's dimensions. When empty, displays according to the variant property.
  *
@@ -20,6 +22,13 @@ import SolidElement from '../../internal/solid-element';
 export default class SdSkeleton extends SolidElement {
   /** The shape variant when used without slotted content. */
   @property({ type: String, reflect: true }) variant: 'rectangular' | 'circular' = 'rectangular';
+
+  connectedCallback() {
+    super.connectedCallback();
+    console.warn(
+      '<sd-skeleton> is deprecated. Use the `sd-skeleton` CSS class directly on the target element instead. See the Styles/sd-skeleton documentation.'
+    );
+  }
 
   render() {
     return html`

--- a/packages/docs/src/stories/components/skeleton.stories.ts
+++ b/packages/docs/src/stories/components/skeleton.stories.ts
@@ -6,6 +6,10 @@ const { argTypes, parameters } = storybookDefaults('sd-skeleton');
 const { overrideArgs } = storybookHelpers('sd-skeleton');
 const { generateTemplate } = storybookTemplate('sd-skeleton');
 
+/**
+ * @deprecated `sd-skeleton` component is deprecated. Use the `sd-skeleton` CSS class instead.
+ * See [Styles/sd-skeleton](./?path=/docs/styles-sd-skeleton--docs).
+ */
 export default {
   tags: ['!dev', 'autodocs'],
   title: 'Components/sd-skeleton',

--- a/packages/docs/src/stories/styles/skeleton.mdx
+++ b/packages/docs/src/stories/styles/skeleton.mdx
@@ -4,7 +4,7 @@ import { OverviewFormatter } from '../../Overview.jsx';
 import * as SdSkeletonStories from './skeleton.stories';
 
 export const links = {
-  'storybook-docs': '/?path=/docs/components-sd-skeleton--docs',
+  'storybook-docs': './?path=/docs/styles-sd-skeleton--docs',
   'figma-library':
     'https://www.figma.com/design/VTztxQ5pWG7ARg8hCX6PfR/Solid-DS-%E2%80%93-Component-Library?node-id=6916-29455&p=f&t=5tBkyJ7uTIMvqPnd-0',
   'figma-docs':
@@ -14,52 +14,73 @@ export const links = {
 export const content = `
 # Skeleton
 
-> **Deprecated:** \`sd-skeleton\` component is deprecated. Use the [\`sd-skeleton\` CSS class](./?path=/docs/styles-sd-skeleton--docs) instead — apply it directly to the target element and remove it once content is loaded.
-
 Used as a placeholder preview of the content before the data gets loaded to reduce load-time frustration.
+
+Apply the \`sd-skeleton\` class directly to the element that will eventually show real content. Remove the class once loading is complete — no wrapper element needed.
 
 <DefaultStory />
 
 <DocumentationLinks links=${JSON.stringify(links, null, 2)} />
 
-#### Related Templates
-
-[Skeleton](./?path=/docs/templates-skeleton--docs)
-
 ### Common Use Cases
 
 - Represent the loading state of specific UI elements like titles, images, and body content on detailed pages.
-
 - Show placeholders for repeating elements such as items in a product grid or a list of search results.
 
 ### Usage Guidelines
 
 **Content and Styling**
 
-- Ensure skeleton screens closely resemble the layout of the final content to provide a smooth transition once the content is loaded.
+- Ensure skeleton screens closely resemble the layout of the final content to provide a smooth transition once content loads.
 - Use a consistent skeleton style across similar components for uniformity.
 - Make skeletons non-interactive placeholders, not functional components.
+
+**Sizing**
+
+- For standalone placeholders (no real element behind them), apply explicit width and height classes alongside \`sd-skeleton\` (e.g. \`class="sd-skeleton h-8 w-48"\`).
+- When applied to an actual element like \`sd-button\`, the skeleton automatically sizes to that element — no width or height needed.
 
 **Behavior and Interaction**
 
 - Use skeletons only for content that takes longer than one second to load, avoiding quick flashes.
-- Avoid showing skeletons for elements that aren't actually loading, as this can confuse or mislead users.
-- Do not rely solely on skeletons for loading feedback; consider providing text like "Loading" for better accessibility.
-- Provide smooth, subtle transitions from the skeleton to the loaded content.
+- Always toggle \`sd-skeleton\` and \`inert\` together (see Accessibility below).
 
 **Performance**
 
-- Ensure skeletons are lightweight to avoid overloading the page with complex or animated elements that can affect performance.
+- Ensure skeletons are lightweight to avoid overloading the page with complex or animated elements.
 
 ### Accessibility Information
 
-- Use aria-hidden="true" on skeleton placeholders so screenreaders skip them.
-- Provide a meaningful status update while skeletons are visible (e.g., “Loading…” or a live region announcing updates) to inform assistive technology users that content is still being retrieved.
+Always pair \`sd-skeleton\` with the native \`inert\` attribute:
+
+\`\`\`html
+
+<!-- Loading -->
+
+<sd-button class="sd-skeleton" inert>Submit form</sd-button>
+
+<!-- Loaded -->
+
+<sd-button>Submit form</sd-button>
+\`\`\`
+
+\`inert\` removes the element from the accessibility tree and prevents focus in a single attribute — screen readers will not announce the placeholder content, and keyboard users cannot tab into it. Remove \`inert\` together with \`sd-skeleton\` when content becomes available.
+
+Additionally, provide a live region so screen reader users know loading is happening:
+
+\`\`\`html
+
+<p role="status" aria-live="polite" class="sr-only">
+  Loading…
+</p>
+\`\`\`
+
+Update or remove the live region once loading completes.
 
 Visit <sd-link href="https://www.figma.com/design/VTztxQ5pWG7ARg8hCX6PfR/Solid-DS-%E2%80%93-Component-Library?node-id=38262-58412&t=1qhfYXrbNhSCYCzZ-4" target="_blank">Solid DS Best Practices for WCAG Compliance</sd-link> to learn more about our accessibility standards.
 
 `;
 
-<Meta title="Components/sd-skeleton/Overview" />
+<Meta title="Styles/sd-skeleton/Overview" />
 
 <OverviewFormatter story={SdSkeletonStories.Default}>{content}</OverviewFormatter>

--- a/packages/docs/src/stories/styles/skeleton.stories.ts
+++ b/packages/docs/src/stories/styles/skeleton.stories.ts
@@ -1,0 +1,96 @@
+import '../../../../components/src/solid-components';
+import { html } from 'lit-html';
+import { storybookDefaults, storybookHelpers, storybookTemplate } from '../../../scripts/storybook/helper';
+
+const { argTypes, parameters } = storybookDefaults('sd-skeleton');
+const { overrideArgs } = storybookHelpers('sd-skeleton');
+const { generateTemplate } = storybookTemplate('sd-skeleton');
+
+export default {
+  title: 'Styles/sd-skeleton',
+  tags: ['!dev', 'autodocs'],
+  component: 'sd-skeleton',
+  args: overrideArgs([{ type: 'attribute', name: 'class', value: 'h-8 w-48' }]),
+  parameters: {
+    ...parameters,
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/YDktJcseQIIQbsuCpoKS4V/Component-Docs'
+    }
+  },
+  argTypes
+};
+
+export const Default = {
+  render: (args: any) => {
+    return generateTemplate({
+      options: { templateContent: '<div class="%CLASSES%"></div>' },
+      args
+    });
+  }
+};
+
+/**
+ * Use `sd-skeleton--circular` for circular placeholders such as avatars or icons.
+ */
+export const Circular = {
+  render: () => html`<div class="sd-skeleton sd-skeleton--circular w-12 h-12"></div>`
+};
+
+/**
+ * Apply `sd-skeleton` and `inert` directly to the element that will be shown after loading.
+ * `inert` hides the element from the accessibility tree and removes focus — no screen reader
+ * will announce "Submit form" while the skeleton is visible.
+ * Remove both attributes once content is ready.
+ */
+export const OnElements = {
+  render: () => html`
+    <div class="flex flex-col gap-6 p-4 w-[392px]">
+      <div>
+        <p class="sd-paragraph text-sm text-neutral-700 mb-2">Button — sizes to its natural width</p>
+        <sd-button class="sd-skeleton" inert>Submit form</sd-button>
+      </div>
+      <div>
+        <p class="sd-paragraph text-sm text-neutral-700 mb-2">Text placeholders — use explicit widths</p>
+        <div class="flex flex-col gap-2">
+          <div class="sd-skeleton h-7 w-3/4" inert></div>
+          <div class="sd-skeleton h-4 w-full" inert></div>
+          <div class="sd-skeleton h-4 w-5/6" inert></div>
+        </div>
+      </div>
+      <div>
+        <p class="sd-paragraph text-sm text-neutral-700 mb-2">Mixed — avatar + text lines</p>
+        <div class="flex gap-3 items-center">
+          <div class="sd-skeleton sd-skeleton--circular w-10 h-10 shrink-0" inert></div>
+          <div class="flex flex-col gap-2 flex-1">
+            <div class="sd-skeleton h-4 w-2/3" inert></div>
+            <div class="sd-skeleton h-3 w-1/2" inert></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  `
+};
+
+/**
+ * Toggle both `sd-skeleton` and `inert` together to switch between loading and loaded states.
+ * Adding `inert` ensures the element is completely inaccessible while loading —
+ * not focusable, not announced by screen readers.
+ */
+export const Toggle = {
+  render: () => html`
+    <div class="flex flex-col items-start gap-4 p-4">
+      <sd-button
+        id="toggle-btn"
+        onclick="
+          const btn = document.getElementById('demo-btn');
+          btn.classList.toggle('sd-skeleton');
+          btn.toggleAttribute('inert');
+        "
+      >
+        Toggle skeleton
+      </sd-button>
+      <sd-button id="demo-btn" class="sd-skeleton" inert>Submit form</sd-button>
+    </div>
+  `
+};

--- a/packages/docs/src/stories/styles/skeleton.test.stories.ts
+++ b/packages/docs/src/stories/styles/skeleton.test.stories.ts
@@ -1,0 +1,76 @@
+import '../../../../components/src/solid-components';
+import { html } from 'lit-html';
+import {
+  storybookDefaults,
+  storybookHelpers,
+  storybookTemplate,
+  storybookUtilities
+} from '../../../scripts/storybook/helper';
+
+const { argTypes, parameters } = storybookDefaults('sd-skeleton');
+const { overrideArgs } = storybookHelpers('sd-skeleton');
+const { generateTemplate } = storybookTemplate('sd-skeleton');
+const { generateScreenshotStory } = storybookUtilities;
+
+export default {
+  title: 'Styles/sd-skeleton/Screenshots: sd-skeleton',
+  tags: ['!autodocs'],
+  component: 'sd-skeleton',
+  parameters: {
+    ...parameters,
+    controls: { disable: true }
+  },
+  args: overrideArgs([{ type: 'attribute', name: 'class', value: 'h-8 w-48' }]),
+  argTypes
+};
+
+export const Default = {
+  name: 'Default',
+  render: (args: any) => {
+    return generateTemplate({
+      options: { templateContent: '<div class="%CLASSES%"></div>' },
+      args
+    });
+  }
+};
+
+export const Variants = {
+  name: 'Variants',
+  render: (args: any) => {
+    return generateTemplate({
+      axis: {
+        y: [
+          {
+            type: 'attribute',
+            name: 'sd-skeleton--variant',
+            values: ['', 'sd-skeleton--circular']
+          }
+        ]
+      },
+      constants: [{ type: 'attribute', name: 'class', value: 'h-12 w-12' }],
+      options: { templateContent: '<div class="%CLASSES%"></div>' },
+      args
+    });
+  }
+};
+
+export const OnElements = {
+  name: 'On Elements',
+  render: () => html`
+    <div class="flex flex-col items-start gap-4 p-4">
+      <sd-button class="sd-skeleton">Submit form</sd-button>
+      <div class="sd-skeleton h-6 w-64"></div>
+      <div class="sd-skeleton h-4 w-48"></div>
+      <div class="sd-skeleton h-4 w-56"></div>
+      <div class="flex gap-3">
+        <div class="sd-skeleton sd-skeleton--circular w-10 h-10"></div>
+        <div class="flex flex-col gap-2">
+          <div class="sd-skeleton h-4 w-32"></div>
+          <div class="sd-skeleton h-3 w-24"></div>
+        </div>
+      </div>
+    </div>
+  `
+};
+
+export const Combination = generateScreenshotStory([Default, Variants, OnElements]);

--- a/packages/styles/src/modules/skeleton.css
+++ b/packages/styles/src/modules/skeleton.css
@@ -1,0 +1,31 @@
+/**
+ * @summary Used as a placeholder preview of the content before the data gets loaded to reduce load-time frustration.
+ * @name sd-skeleton
+ * @status stable
+ * @since 6.17.0
+ * @boolean sd-skeleton--circular Makes the skeleton appear circular.
+ *
+ * @cssproperty --sd-skeleton-color - The color of the skeleton.
+ */
+
+.sd-skeleton {
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+  pointer-events: none;
+  @apply animate-pulse;
+
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    @apply sd-skeleton-color rounded-sm;
+    z-index: 11;
+  }
+
+  &--circular {
+    &::after {
+      @apply rounded-full;
+    }
+  }
+}

--- a/packages/styles/src/solid-styles.css
+++ b/packages/styles/src/solid-styles.css
@@ -7,6 +7,7 @@
 @import './modules/mark.css';
 @import './modules/meta.css';
 @import './modules/pagination.css';
+@import './modules/skeleton.css';
 @import './modules/status-badge.css';
 /* plop:style */
 @import './modules/prose.css';


### PR DESCRIPTION
Introduce `sd-skeleton` as a CSS utility class in `packages/styles/src/modules/skeleton.css`. The class uses a `::after` overlay with `isolation: isolate` so it correctly covers shadow DOM elements (e.g. `sd-button`) without z-index leakage, and animates the host rather than the overlay to prevent opacity bleed-through at mid-pulse.

Pair with the native `inert` attribute to remove the element from the a11y tree and prevent focus during loading — toggle both together.

Deprecate `<sd-skeleton>` web component with `@status deprecated` and a runtime `console.warn`.

Add `Styles/sd-skeleton` stories (overview, variants, on-elements, toggle demo) and screenshot test stories. Update component stories with deprecation notices.

Also fix ESLint config to disable `no-unsafe-call` for `*.spec.ts` files (was only `*.test.ts`).

<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
<!-- *PR notes: Please describe the changes in this PR.* -->

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
<!-- *PR notes: If this PR includes a BREAKING CHANGE, a migration guide is needed to explain how users can migrate between versions. * -->
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
