### PR TITLE
fix: fix text wrapping in sd-radio

### DIFF
--- a/.changeset/fluffy-planets-dig.md
+++ b/.changeset/fluffy-planets-dig.md
@@ -2,4 +2,4 @@
 '@solid-design-system/components': patch
 ---
 
-Fixed text wrapping in sd-radio
+Fixed text wrapping in `sd-radio`

--- a/.changeset/fluffy-planets-dig.md
+++ b/.changeset/fluffy-planets-dig.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/components': patch
+---
+
+Fixed text wrapping in sd-radio

--- a/packages/components/src/components/checkbox/checkbox.ts
+++ b/packages/components/src/components/checkbox/checkbox.ts
@@ -250,7 +250,7 @@ export default class SdCheckbox extends SolidElement implements SolidFormControl
               ? ' control--indeterminate'
               : ''}"
             class=${cx(
-              'relative flex flex-shrink-0 items-center justify-center border sd-checkbox-border-width rounded-sm h-4 w-4',
+              'relative flex shrink-0 items-center justify-center border sd-checkbox-border-width rounded-sm h-4 w-4',
               'transition-colors ease-in-out duration-medium group-hover:duration-fast',
               'peer-focus-visible:outline peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-primary outline-transparent',
               {

--- a/packages/components/src/components/radio/radio.ts
+++ b/packages/components/src/components/radio/radio.ts
@@ -121,7 +121,7 @@ export default class SdRadio extends SolidElement {
       <span
         part="base"
         class=${cx(
-          'sd-radio group flex items-center text-base leading-normal text-black cursor-pointer',
+          'sd-radio group flex items-start text-base leading-normal text-black cursor-pointer',
           (this.disabled || this.visuallyDisabled) && 'hover:cursor-not-allowed',
           {
             /* sizes, fonts */
@@ -186,7 +186,7 @@ export default class SdRadio extends SolidElement {
     ...SolidElement.styles,
     css`
       :host {
-        @apply block w-max;
+        @apply block;
       }
 
       :host(:focus-visible) {
@@ -202,6 +202,16 @@ export default class SdRadio extends SolidElement {
       :host(:focus-visible) [part='control--checked'],
       :host(:focus-visible) [part='control--unchecked'] {
         @apply outline outline-2 outline-primary outline-offset-2;
+      }
+
+      /* Margins for circle to center it with the label text */
+      [part='control--unchecked'],
+      [part='control--checked'] {
+        margin-top: 0.23em;
+      }
+      :host([size='sm']) [part='control--unchecked'],
+      :host([size='sm']) [part='control--checked'] {
+        margin-top: 0.15em;
       }
     `
   ];

--- a/packages/docs/src/stories/components/checkbox.test.stories.ts
+++ b/packages/docs/src/stories/components/checkbox.test.stories.ts
@@ -335,5 +335,6 @@ export const Combination = generateScreenshotStory([
   Invalid,
   IndeterminateInvalid,
   Parts,
+  LongLabelWithWrapping,
   setCustomValidity
 ]);

--- a/packages/docs/src/stories/components/checkbox.test.stories.ts
+++ b/packages/docs/src/stories/components/checkbox.test.stories.ts
@@ -252,6 +252,18 @@ const checkboxTemplate = (part: string) => {
   }
 };
 
+export const LongLabelWithWrapping = {
+  name: 'Long Label with Wrapping',
+  render: () => {
+    return `
+      <style>#long-label sd-checkbox{width: 200px}</style>
+      <div id="long-label">
+          <sd-checkbox value="1">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec suscipit auctor dui, sed efficitur ipsum.</sd-checkbox>
+      </div>
+    `;
+  }
+};
+
 export const setCustomValidity = {
   name: 'setCustomValidity',
   parameters: {

--- a/packages/docs/src/stories/components/checkbox.test.stories.ts
+++ b/packages/docs/src/stories/components/checkbox.test.stories.ts
@@ -254,14 +254,19 @@ const checkboxTemplate = (part: string) => {
 
 export const LongLabelWithWrapping = {
   name: 'Long Label with Wrapping',
-  render: () => {
-    return `
-      <style>#long-label sd-checkbox{width: 200px}</style>
-      <div id="long-label">
-          <sd-checkbox value="1">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec suscipit auctor dui, sed efficitur ipsum.</sd-checkbox>
-      </div>
-    `;
-  }
+  render: () => html`
+    <style>
+      #long-label sd-checkbox {
+        width: 200px;
+      }
+    </style>
+    <div id="long-label">
+      <sd-checkbox value="1"
+        >Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec suscipit auctor dui, sed efficitur
+        ipsum.</sd-checkbox
+      >
+    </div>
+  `
 };
 
 export const setCustomValidity = {

--- a/packages/docs/src/stories/components/radio.test.stories.ts
+++ b/packages/docs/src/stories/components/radio.test.stories.ts
@@ -1,4 +1,5 @@
 import '../../../../components/src/solid-components';
+import { html } from 'lit';
 import {
   storybookDefaults,
   storybookHelpers,
@@ -95,16 +96,21 @@ export const Invalid = {
 
 export const LongLabelWithWrapping = {
   name: 'Long Label with Wrapping',
-  render: () => {
-    return `
-      <style>#long-label sd-radio-group{width: 200px}</style>
-      <div id="long-label">
-        <sd-radio-group value="1">
-          <sd-radio value="1">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec suscipit auctor dui, sed efficitur ipsum.</sd-radio>
-        </sd-radio-group>
-      </div>
-    `;
-  }
+  render: () => html`
+    <style>
+      #long-label sd-radio-group {
+        width: 200px;
+      }
+    </style>
+    <div id="long-label">
+      <sd-radio-group value="1">
+        <sd-radio value="1"
+          >Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec suscipit auctor dui, sed efficitur
+          ipsum.</sd-radio
+        >
+      </sd-radio-group>
+    </div>
+  `
 };
 
 /**

--- a/packages/docs/src/stories/components/radio.test.stories.ts
+++ b/packages/docs/src/stories/components/radio.test.stories.ts
@@ -93,6 +93,20 @@ export const Invalid = {
   }
 };
 
+export const LongLabelWithWrapping = {
+  name: 'Long Label with Wrapping',
+  render: () => {
+    return `
+      <style>#long-label sd-radio-group{width: 200px}</style>
+      <div id="long-label">
+        <sd-radio-group value="1">
+          <sd-radio value="1">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec suscipit auctor dui, sed efficitur ipsum.</sd-radio>
+        </sd-radio-group>
+      </div>
+    `;
+  }
+};
+
 /**
  * Use the `base`, `control--unchecked`, `control--checked`, `checked` and `label` part selectors to customize the radio.
  */
@@ -127,4 +141,11 @@ export const Parts = {
   }
 };
 
-export const Combination = generateScreenshotStory([Default, DisabledAndSize, Size, Invalid, Parts]);
+export const Combination = generateScreenshotStory([
+  Default,
+  DisabledAndSize,
+  Size,
+  Invalid,
+  LongLabelWithWrapping,
+  Parts
+]);


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
Fix text wrapping in sd-radio that it aligns with the available space

## Definition of Reviewable:
- [x] E2E tests (features, a11y, bug fixes) are created/updated
- [x] relevant tickets are linked
