### PR TITLE
feat: expose ./package.json in exports

### DIFF
--- a/.changeset/expose-package-json-in-exports.md
+++ b/.changeset/expose-package-json-in-exports.md
@@ -3,4 +3,4 @@
 "@solid-design-system/tokens": minor
 ---
 
-Expose `./package.json` in the package exports so you can read the installed version programmatically, for example `import pkg from '@solid-design-system/components/package.json' with { type: 'json' }` or `require.resolve('@solid-design-system/components/package.json')`. Previously the exports map blocked this subpath.
+Expose `./package.json` in the package exports so you can read the installed version programmatically, for example `import pkg from '@solid-design-system/components/package.json' with { type: 'json' }` or `require.resolve('@solid-design-system/components/package.json')`.

--- a/.changeset/expose-package-json-in-exports.md
+++ b/.changeset/expose-package-json-in-exports.md
@@ -1,6 +1,6 @@
 ---
-"@solid-design-system/components": patch
-"@solid-design-system/tokens": patch
+"@solid-design-system/components": minor
+"@solid-design-system/tokens": minor
 ---
 
 Expose `./package.json` in the package exports so you can read the installed version programmatically, for example `import pkg from '@solid-design-system/components/package.json' with { type: 'json' }` or `require.resolve('@solid-design-system/components/package.json')`. Previously the exports map blocked this subpath.

--- a/.changeset/expose-package-json-in-exports.md
+++ b/.changeset/expose-package-json-in-exports.md
@@ -1,0 +1,6 @@
+---
+"@solid-design-system/components": patch
+"@solid-design-system/tokens": patch
+---
+
+Expose `./package.json` in the package exports so you can read the installed version programmatically, for example `import pkg from '@solid-design-system/components/package.json' with { type: 'json' }` or `require.resolve('@solid-design-system/components/package.json')`. Previously the exports map blocked this subpath.

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -19,6 +19,7 @@
       "types": "./dist/solid-components.d.ts",
       "import": "./dist/solid-components.js"
     },
+    "./package.json": "./package.json",
     "./dist/custom-elements.json": "./dist/custom-elements.json",
     "./dist/solid-components.js": "./dist/solid-components.js",
     "./dist/solid-components.css": "./dist/solid-components.css",

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -21,6 +21,7 @@
     "cdn"
   ],
   "exports": {
+    "./package.json": "./package.json",
     "./dist/tailwind.json": "./dist/tokens.tailwind.json",
     "./dist/tailwind.css": "./dist/themes/tailwind.css",
     "./dist/themes": "./dist/themes",


### PR DESCRIPTION
## Description:

Add `"./package.json": "./package.json"` to the `exports` map of the published packages so downstream consumers can resolve and read the package's own `package.json` — most usefully to read the installed `version` — programmatically.

- `packages/components/package.json` — added, placed right after the existing `"."` entry.
- `packages/tokens/package.json` — added as the first `exports` entry (this package has no `"."` entry).
- `packages/styles/package.json` — already had this entry; unchanged.

No other exports were touched; there is no version-constant export and no build changes. A patch changeset is included.

### Why

Today the published `exports` map gates subpath access and there is no `./package.json` export, so a consumer hits `ERR_PACKAGE_PATH_NOT_EXPORTED`:

```js
require.resolve('@solid-design-system/components/package.json') // throws today
```

This complements #1059 — which surfaces the version only as a rendered `data-sd-version` DOM attribute via build-time injection — by giving **programmatic** access to the version rather than a DOM-only attribute. The two approaches are independent and address different use cases (runtime/tooling reads vs. inspecting rendered markup).

Re-exposing `package.json` through `exports` is a well-established convention (React and many other libraries do exactly this). It exposes no new information — the published manifest is already public on the npm registry; this only makes it resolvable through Node's module-resolution algorithm.

### Verification

Each touched package was packed (`npm pack`) and installed into a clean local project from the tarballs:

- `require.resolve('@solid-design-system/components/package.json')` succeeds (CJS) — same for `tokens` and `styles`.
- `import.meta.resolve('@solid-design-system/components/package.json')` succeeds (ESM) — same for `tokens` and `styles`.
- Importing the JSON and reading `.version` returns the current version.
- Negative control: an unlisted subpath (e.g. `.../README.md`) still correctly throws `ERR_PACKAGE_PATH_NOT_EXPORTED`, confirming the gate is unchanged apart from the added entry.
- `npm pack --dry-run` file lists are identical before and after for both touched packages — packed output is otherwise unchanged.

## Definition of Reviewable:
- [x] No documentation changes required (purely additive `exports` entry; behaviour for existing subpaths is unchanged)
- [x] No migration guide required (non-breaking, additive)
- [x] No E2E/visual changes (no component, story, or rendered behaviour is affected)
- ~~Stories created/updated~~ — N/A
- Related: #1059
