### PR TITLE
fix: height of large combobox with floating label

### DIFF
--- a/.changeset/every-bags-poke.md
+++ b/.changeset/every-bags-poke.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/components': patch
+---
+
+Fix height of large combobox with floating label.

--- a/packages/components/src/components/combobox/combobox.ts
+++ b/packages/components/src/components/combobox/combobox.ts
@@ -1285,7 +1285,11 @@ export default class SdCombobox extends SolidElement implements SolidFormControl
                   class=${cx(
                     'absolute left-4 z-20 pointer-events-none transition-all duration-200',
                     hasIconLeft ? floatingLabelHorizontalAlignmentWithIconLeft : 'left-4',
-                    !isFloatingLabelActive ? 'top-1/2 -translate-y-1/2 form-control-color-text' : 'top-1 text-xs',
+                    !isFloatingLabelActive
+                      ? 'top-1/2 -translate-y-1/2 form-control-color-text'
+                      : this.size === 'lg'
+                        ? 'top-2 text-xs'
+                        : 'top-1 text-xs',
                     isFloatingLabelActive && 'mt-1'
                   )}
                   for="input"

--- a/packages/components/src/components/combobox/combobox.ts
+++ b/packages/components/src/components/combobox/combobox.ts
@@ -1239,9 +1239,7 @@ export default class SdCombobox extends SolidElement implements SolidFormControl
       this.size === 'lg'
         ? !this.floatingLabel
           ? 'py-2'
-          : isFloatingLabelActive
-            ? 'py-3'
-            : 'py-4'
+          : 'py-3'
         : !this.floatingLabel
           ? 'py-1'
           : isFloatingLabelActive
@@ -1287,11 +1285,7 @@ export default class SdCombobox extends SolidElement implements SolidFormControl
                   class=${cx(
                     'absolute left-4 z-20 pointer-events-none transition-all duration-200',
                     hasIconLeft ? floatingLabelHorizontalAlignmentWithIconLeft : 'left-4',
-                    !isFloatingLabelActive
-                      ? 'top-1/2 -translate-y-1/2 form-control-color-text'
-                      : this.size === 'lg'
-                        ? 'top-2 text-xs'
-                        : 'top-1 text-xs',
+                    !isFloatingLabelActive ? 'top-1/2 -translate-y-1/2 form-control-color-text' : 'top-1 text-xs',
                     isFloatingLabelActive && 'mt-1'
                   )}
                   for="input"
@@ -1378,7 +1372,11 @@ export default class SdCombobox extends SolidElement implements SolidFormControl
                   ></slot>`
                 : ''}
               <div
-                class=${cx('flex flex-wrap items-center gap-1 w-full min-w-0 relative', this.floatingLabel && 'mt-4')}
+                class=${cx(
+                  'flex flex-wrap items-center gap-1 w-full min-w-0 relative',
+                  this.floatingLabel && isFloatingLabelActive && 'mt-4',
+                  this.floatingLabel && !isFloatingLabelActive && this.size === 'lg' && 'mt-2'
+                )}
               >
                 ${this.multiple && this.useTags && this.tags && this.tags.length > 0
                   ? html`<div part="tags" class="${cx('flex flex-wrap items-center gap-1 min-w-0', iconMarginRight)}">


### PR DESCRIPTION
## Description:
The large combobox with a floating label had an incorrect height of 80px, which did not match the Figma specifications. This PR updates the component height to 64px to align with the design.

## Definition of Reviewable:
- [x] relevant tickets are linked
