### PR TITLE
fix: add sparda icons in multi theming and sparda name to SP

### DIFF
--- a/.changeset/famous-cycles-sort.md
+++ b/.changeset/famous-cycles-sort.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/components': minor
+---
+
+Add Sparda theme icons to the multi-theming icon library.

--- a/packages/components/src/components/icon/library.multi-theming.ts
+++ b/packages/components/src/components/icon/library.multi-theming.ts
@@ -5,7 +5,7 @@ const themeMap: Record<string, string> = {
   'ui-dark': 'union-investment',
   vb: 'vb',
   bb: 'bbbank',
-  sp: 'sp',
+  sp: 'sparda',
   kid: 'kidstarter'
 };
 

--- a/packages/docs/.storybook/manager.ts
+++ b/packages/docs/.storybook/manager.ts
@@ -14,7 +14,7 @@ addons.setConfig({
 const PROTECTED_THEMES: Record<string, { id: string; password: string }> = {
   BBBank: { id: 'sd-theme-bb', password: 'iGnJgoyi9vo1jMrUa29PmiRAdHgWQLL5LniY62wg' },
   KidStarter: { id: 'sd-theme-kid', password: 'd7be651c2073ccb8a9897f1bc8bfa2cb7811f693' },
-  Sparda: { id: 'sd-theme-sp', password: 'TqfRmtMeWRDnEjREpXs3AWJ8NwJ9hM99JcC2K4Fy' },
+  SP: { id: 'sd-theme-sp', password: 'TqfRmtMeWRDnEjREpXs3AWJ8NwJ9hM99JcC2K4Fy' },
   VB: { id: 'sd-theme-vb', password: '381a5cca78c0e498082cf82a5e20c95f' }
 };
 

--- a/packages/docs/.storybook/modes.js
+++ b/packages/docs/.storybook/modes.js
@@ -5,7 +5,7 @@ export const themes = [
   { id: 'sd-theme-ui-dark', name: 'UI Dark' },
   { id: 'sd-theme-vb', name: 'VB' },
   { id: 'sd-theme-bb', name: 'BBBank' },
-  { id: 'sd-theme-sp', name: 'Sparda' },
+  { id: 'sd-theme-sp', name: 'SP' },
   { id: 'sd-theme-kid', name: 'KidStarter' }
 ];
 
@@ -23,7 +23,7 @@ export const allModes = {
     theme: 'BBBank'
   },
   'sd-theme-sp': {
-    theme: 'Sparda'
+    theme: 'SP'
   },
   'sd-theme-kid': {
     theme: 'KidStarter'

--- a/packages/mcp/metadata/packages/tokens/docs/installation.md
+++ b/packages/mcp/metadata/packages/tokens/docs/installation.md
@@ -121,7 +121,7 @@ sans-serif;
 
 </sd-accordion>
 
-<sd-accordion summary="Example CSS for Sparda (CDN)">
+<sd-accordion summary="Example CSS for SP (CDN)">
 ```css
 @font-face {
   font-family: 'GenosGFG';

--- a/packages/mcp/metadata/packages/tokens/docs/installation.md
+++ b/packages/mcp/metadata/packages/tokens/docs/installation.md
@@ -121,7 +121,7 @@ sans-serif;
 
 </sd-accordion>
 
-<sd-accordion summary="Example CSS for SP (CDN)">
+<sd-accordion summary="Example CSS for Sparda (CDN)">
 ```css
 @font-face {
   font-family: 'GenosGFG';

--- a/packages/tokens/CONTRIBUTING.md
+++ b/packages/tokens/CONTRIBUTING.md
@@ -40,7 +40,7 @@ To register a new theme in Storybook:
 
 #### Adding system and content icons
 
-1. Ensure the icons are available in the CDN.
+1. Ensure the icons are available in the CDN under the url https://celum-icons.fe.union-investment.de/`<your-theme-folder>`/system.json.
 2. Add the CDN folder name to `ThemeMap` using the same key that references the theme throughout the project.
 3. Update `icon.libraries.multi-theming.stories` by adding the new theme to both the **Content** and **System** modes.
 4. Add a new example section for the theme in the **Multi-theming Library** story.

--- a/packages/tokens/CONTRIBUTING.md
+++ b/packages/tokens/CONTRIBUTING.md
@@ -40,7 +40,7 @@ To register a new theme in Storybook:
 
 #### Adding system and content icons
 
-1. Ensure the icons are available in the CDN under the url https://celum-icons.fe.union-investment.de/`<your-theme-folder>`/system.json.
+1. Ensure the icons are available in the CDN at https://celum-icons.fe.union-investment.de/`<your-theme-folder>`/system.json for system icons and https://celum-icons.fe.union-investment.de/`<your-theme-folder>`/content.json for content icons.
 2. Add the CDN folder name to `ThemeMap` using the same key that references the theme throughout the project.
 3. Update `icon.libraries.multi-theming.stories` by adding the new theme to both the **Content** and **System** modes.
 4. Add a new example section for the theme in the **Multi-theming Library** story.


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
- Fixes the sparda icons not rendering in the multi theming library
- Replaces the "Sparda" name to "SP" to keep concistency with figma

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [x] Documentation is created/updated