### PR TITLE
fix: removing recursive flag from changeset release command

### DIFF
--- a/.changeset/floppy-cougars-peel.md
+++ b/.changeset/floppy-cougars-peel.md
@@ -1,0 +1,6 @@
+---
+'@solid-design-system/styles': patch
+'@solid-design-system/mcp': patch
+---
+
+Fix versioned icons to work with next versions.

--- a/packages/mcp/test/utilities/version.spec.ts
+++ b/packages/mcp/test/utilities/version.spec.ts
@@ -31,7 +31,7 @@ describe('when using the version utilities', () => {
       const version = getVersion();
       assert.notStrictEqual(version, undefined);
       assert.strictEqual(typeof version, 'string');
-      assert.match(version, /^\d+\.\d+\.\d+$/);
+      assert.match(version, /^\d+\.\d+\.\d+(-[\w.]+)?$/);
     });
 
     it('should match the version from getPackageInfo', () => {

--- a/packages/styles/scripts/test.js
+++ b/packages/styles/scripts/test.js
@@ -19,8 +19,8 @@ test('sd-icon element selector should be versioned inside sd-status-badge rules'
     'Found unversioned "sd-icon" as a CSS descendant selector in dist-versioned output'
   );
 
-  // Versioned sd-icon must appear (e.g. sd-6-15-1-icon)
-  const versionedIconSelector = /sd-\d+-\d+-\d+-icon/;
+  // Versioned sd-icon must appear (e.g. sd-6-15-1-icon or sd-7-0-0-next-0-icon)
+  const versionedIconSelector = /sd-\d+(-\d+)*(-\w+)*-icon/;
   assert.ok(
     versionedIconSelector.test(css),
     'Expected to find a versioned "sd-<version>-icon" selector in dist-versioned output'

--- a/scripts/release-next.mjs
+++ b/scripts/release-next.mjs
@@ -74,7 +74,7 @@ async function main() {
     execSync('git push origin next', { stdio: 'inherit' });
 
     console.log('Publishing to NPM...');
-    execSync('pnpm changeset publish -r', { stdio: 'inherit' });
+    execSync('pnpm changeset publish', { stdio: 'inherit' });
 
     console.log('Pushing tags...');
     execSync('git push --tags', { stdio: 'inherit' });


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
- Fix changeset publishing command issues
- Fix versioned icons issue

## Definition of Reviewable:
<!-- *PR notes: Irrelevant elements should be removed.* -->
- [ ] Documentation is created/updated
- [ ] Migration Guide is created/updated
<!-- *PR notes: If this PR includes a BREAKING CHANGE, a migration guide is needed to explain how users can migrate between versions. * -->
- [ ] E2E tests (features, a11y, bug fixes) are created/updated
<!-- *If this PR includes a bug fix, an E2E test is necessary to verify the change. If the fix is purely visual, ensuring it is captured within our chromatic screenshot tests is sufficient.* -->
- [ ] Stories (features, a11y) are created/updated
- [ ] relevant tickets are linked
