### PR TITLE
feat: replaced warning with risk icon in sd-notification

### DIFF
--- a/.changeset/free-pots-travel.md
+++ b/.changeset/free-pots-travel.md
@@ -1,0 +1,5 @@
+---
+'@solid-design-system/components': patch
+---
+
+Removed warning icon from `sd-notification`.

--- a/packages/components/src/components/notification/notification.ts
+++ b/packages/components/src/components/notification/notification.ts
@@ -321,7 +321,7 @@ export default class SdNotification extends SolidElement {
                   info: 'info-circle',
                   success: 'confirm-circle',
                   warning: 'exclamation-circle',
-                  error: 'warning'
+                  error: 'risk'
                 }[this.variant] || ''
               }
               library="_internal"


### PR DESCRIPTION
<!-- ## Title: Please consider adding the [skip chromatic] flag to the PR title in case you dont need chromatic testing your changes. -->
## Description:
<!-- *PR notes: Please describe the changes in this PR.* -->
Closes https://github.com/solid-design-system/internal/issues/169
## Definition of Reviewable:
- [x] relevant tickets are linked
